### PR TITLE
up.sh: run `nox-review wip` before commiting

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -227,6 +227,7 @@ These checks were done:
 - built on NixOS
 $CHECK_RESULT"
 
+nox-review wip
 git commit -am "$COMMIT_MESSAGE"
 
 # Try to push it three times


### PR DESCRIPTION
The current checklist for filing new patches suggests to run `nox-review wip` to ensure
that the current change (e.g. package bumps) don't break package bumps:
https://github.com/NixOS/nixpkgs/blob/e1dee4efcbffc72260025078bf8297a3b732509c/.github/PULL_REQUEST_TEMPLATE.md

I experienced this behavior from time to time (see NixOS/nixpkgs#38513
or NixOS/nixpkgs#38361) which cost me some extra time to spot the
reasons for additional breackage.

Running `nox-review wip` can be quite time consuming, especially when
bumping packages that trigger a mass-rebuild or a stdenv rebuild,
*however* this patch helps to reduce the risk of additional breackage
caused by unwanted package bumps.