### PR TITLE
Recommend running Cachix with Nix shell

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -290,11 +290,9 @@ prMessage updateEnv isBroken metaDescription releaseUrlMessage compareUrlMessage
        </summary>
 
        One-time optional setup to skip building using Cachix:
-       1. Install cachix from https://cachix.org/
-       2. Use r-ryantm's cache:
-          ```
-          cachix use r-ryantm
-          ```
+       ```
+       nix-shell -p cachix --run 'cachix use r-ryantm'
+       ```
 
        Test this update by entering a nix shell, seeing what is inside the
        result, and if applicable, running some binaries:


### PR DESCRIPTION
Cachix has landed to Nixpkgs in https://github.com/NixOS/nixpkgs/commit/d55976a5062c270dee4342024b6e832a5eaec29a and is present in 18.09 release.