### PR TITLE
Include meta.homepage

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -17,6 +17,7 @@ module Nix
   , parseStringList
   , build
   , getDescription
+  , getHomepage
   , cachix
   , assertOneOrFewerFetcher
   , getHashFromBuild
@@ -156,6 +157,14 @@ getDescription attrPath =
     ("(let pkgs = import ./. {}; in pkgs." <> attrPath <>
      ".meta.description or \"\")") &
   overwriteErrorT ("Could not get meta.description for attrpath " <> attrPath)
+
+getHomepage :: MonadIO m => Text -> ExceptT Text m Text
+getHomepage attrPath =
+  nixEvalET
+    NoRaw
+    ("(let pkgs = import ./. {}; in pkgs." <> attrPath <>
+     ".meta.homepage or \"\")") &
+  overwriteErrorT ("Could not get meta.homepage for attrpath " <> attrPath)
 
 getSrcUrl :: MonadIO m => Text -> ExceptT Text m Text
 getSrcUrl =

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -179,8 +179,11 @@ publishPackage log updateEnv oldSrcUrl newSrcUrl attrPath result opDiff = do
       Right () -> lift $ Check.result updateEnv result
       Left msg -> pure msg
   d <- Nix.getDescription attrPath
+  u <- Nix.getHomepage attrPath
   let metaDescription =
         "\n\nmeta.description for " <> attrPath <> " is: '" <> d <> "'."
+  let metaHomepage =
+        "\n\nmeta.homepage for " <> attrPath <> " is: '" <> u
   releaseUrlMessage <-
     (do msg <- GH.releaseUrl newSrcUrl
         return ("\n[Release on GitHub](" <> msg <> ")\n\n")) <|>
@@ -212,6 +215,7 @@ publishPackage log updateEnv oldSrcUrl newSrcUrl attrPath result opDiff = do
          updateEnv
          isBroken
          metaDescription
+         metaHomepage
          releaseUrlMessage
          compareUrlMessage
          resultCheckReport
@@ -259,7 +263,8 @@ prMessage ::
   -> Text
   -> Text
   -> Text
-prMessage updateEnv isBroken metaDescription releaseUrlMessage compareUrlMessage resultCheckReport commitHash attrPath maintainersCc resultPath opReport =
+  -> Text
+prMessage updateEnv isBroken metaDescription metaHomepage releaseUrlMessage compareUrlMessage resultCheckReport commitHash attrPath maintainersCc resultPath opReport =
   let brokenMsg = brokenWarning isBroken
       title = prTitle updateEnv attrPath
       repologyLink = repologyUrl updateEnv


### PR DESCRIPTION
It's helpful to be able to quickly learn about a project, look up documentation, etc. when doing PR reviews.