### PR TITLE
Check: build passthru.tests when present

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -37,7 +37,7 @@ import System.Exit
 import Text.Parsec (parse)
 import Text.Parser.Combinators
 import Text.Parser.Token
-import Utils (UpdateEnv(..), overwriteErrorT, srcOrMain)
+import Utils (UpdateEnv(..), nixBuildOptions, overwriteErrorT, srcOrMain)
 
 data Raw
   = Raw
@@ -184,20 +184,7 @@ getSrcUrls = getSrcAttr "urls"
 buildCmd :: Text -> ProcessConfig () () ()
 buildCmd attrPath =
   silently $
-  proc
-    "nix-build"
-    [ "--option"
-    , "sandbox"
-    , "true"
-    , "--option"
-    , "restrict-eval"
-    , "true"
-    , "--arg"
-    , "config"
-    , "{ allowBroken = true; allowUnfree = true; allowAliases = false; }"
-    , "-A"
-    , attrPath & T.unpack
-    ]
+  proc "nix-build" (nixBuildOptions ++ ["-A", attrPath & T.unpack])
 
 log :: Text -> ProcessConfig () () ()
 log attrPath = proc "nix" ["log", "-f", ".", attrPath & T.unpack]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -15,6 +15,7 @@ module Utils
   , runtimeDir
   , srcOrMain
   , prTitle
+  , nixBuildOptions
   ) where
 
 import OurPrelude
@@ -133,3 +134,16 @@ tRead = read . T.unpack
 
 srcOrMain :: MonadIO m => (Text -> ExceptT Text m a) -> Text -> ExceptT Text m a
 srcOrMain et attrPath = et (attrPath <> ".src") <|> et attrPath
+
+nixBuildOptions :: [String]
+nixBuildOptions =
+  [ "--option"
+  , "sandbox"
+  , "true"
+  , "--option"
+  , "restrict-eval"
+  , "true"
+  , "--arg"
+  , "config"
+  , "{ allowBroken = true; allowUnfree = true; allowAliases = false; }"
+  ]


### PR DESCRIPTION
This is my first attempt at haskell in a quite long time, and I haven't been able to `nix-build` the file produced by `cabal2nix` even before my changes (maybe due to my being on 19.03?), so it's quite possible that this does not even parse.

Other than that, I've tried to keep things consistent, and hopefully this should work!