### PR TITLE
Check: fix restrict-eval issue

### DIFF
--- a/src/Check.hs
+++ b/src/Check.hs
@@ -36,7 +36,9 @@ checkTestsBuild :: Text -> Sh Bool
 checkTestsBuild attrPath =
   let nixBuildCmd =
         nixBuildOptions ++
-        [ "-E"
+        [ "-I"
+        , "allow-here-access=."
+        , "-E"
         , "{ config }: (import ./. { inherit config; })." ++
             (T.unpack attrPath) ++ ".tests or {}"
         ]


### PR DESCRIPTION
Assuming that the command is actually run at the root of the nixpkgs tree, this should work to whitelist the directory for import.