### PR TITLE
WIP Caching and querying of CVE data

### DIFF
--- a/nixpkgs-update.nix
+++ b/nixpkgs-update.nix
@@ -1,8 +1,10 @@
-{ mkDerivation, base, bytestring, containers, directory, doctest
-, errors, filepath, github, hpack, lifted-base, mtl
+{ mkDerivation, aeson, base, bytestring, conduit, containers
+, cryptohash-sha256, directory, doctest, errors, filepath, github
+, hex, hpack, http-conduit, iso8601-time, lifted-base, mtl
 , neat-interpolation, optparse-applicative, parsec, parsers
-, regex-applicative-text, shelly, stdenv, template-haskell, text
-, time, transformers, typed-process, unix, vector, xdg-basedir
+, polysemy, regex-applicative-text, shelly, stdenv
+, template-haskell, text, time, transformers, typed-process, unix
+, vector, xdg-basedir, zlib
 }:
 mkDerivation {
   pname = "nixpkgs-update";
@@ -12,19 +14,22 @@ mkDerivation {
   isExecutable = true;
   libraryToolDepends = [ hpack ];
   executableHaskellDepends = [
-    base bytestring containers directory errors filepath github
+    aeson base bytestring conduit containers cryptohash-sha256
+    directory errors filepath github hex http-conduit iso8601-time
     lifted-base mtl neat-interpolation optparse-applicative parsec
-    parsers regex-applicative-text shelly template-haskell text time
-    transformers typed-process unix vector xdg-basedir
+    parsers polysemy regex-applicative-text shelly template-haskell
+    text time transformers typed-process unix vector xdg-basedir zlib
   ];
   testHaskellDepends = [
-    base bytestring containers directory doctest errors filepath github
-    lifted-base mtl neat-interpolation optparse-applicative parsec
-    parsers regex-applicative-text shelly template-haskell text time
-    transformers typed-process unix vector xdg-basedir
+    aeson base bytestring conduit containers cryptohash-sha256
+    directory doctest errors filepath github hex http-conduit
+    iso8601-time lifted-base mtl neat-interpolation
+    optparse-applicative parsec parsers polysemy regex-applicative-text
+    shelly template-haskell text time transformers typed-process unix
+    vector xdg-basedir zlib
   ];
-  preConfigure = "hpack";
+  prePatch = "hpack";
   homepage = "https://github.com/ryantm/nixpkgs-update#readme";
   description = "Tool for semi-automatic updating of nixpkgs repository";
-  license = stdenv.lib.licenses.publicDomain;
+  license = stdenv.lib.licenses.cc0;
 }

--- a/package.yaml
+++ b/package.yaml
@@ -31,13 +31,19 @@ default-extensions:
   - TypeOperators
 
 dependencies:
+  - aeson
   - base >= 4.7 && < 5
   - bytestring
+  - conduit
   - containers
+  - cryptohash-sha256
   - directory >= 1.3 && < 1.4
   - errors
   - filepath
   - github
+  - hex
+  - http-conduit
+  - iso8601-time
   - lifted-base
   - mtl
   - neat-interpolation >= 0.3 && < 0.4
@@ -55,6 +61,7 @@ dependencies:
   - unix
   - vector
   - xdg-basedir
+  - zlib
 
 executables:
   nixpkgs-update:

--- a/src/CVE.hs
+++ b/src/CVE.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module CVE
+  ( parseFeed
+  , CVE
+  ) where
+
+import OurPrelude
+
+import Data.Aeson
+  (FromJSON, Object, eitherDecode, parseJSON, withObject, withText, (.:),
+  (.:!))
+import Data.Aeson.Types (Parser)
+import Data.Bifunctor (bimap)
+import Data.Map (Map)
+import Data.Text.Read (decimal)
+import Data.Time.Clock (UTCTime)
+
+import Utils (Boundary(..), ProductID, Version, VersionMatcher(..))
+
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.Map as M
+import qualified Data.Text as T
+
+data CVE = CVE
+  { cveID :: Text
+  , cveYear :: Int
+  , cveSubID :: Int
+  , cveAffects :: Map ProductID [VersionMatcher]
+  , cveDescriptions :: Text
+  , cveCPEs :: [CPE]
+  , cvePublished :: UTCTime
+  , cveLastModified :: UTCTime
+  } deriving (Show)
+
+data CPE = CPE
+  { cpePart :: Text
+  , cpeVendor :: Text
+  , cpeProduct :: Text
+  , cpeVersion :: Text
+  , cpeUpdate :: Text
+  , cpeEdition :: Text
+  , cpeLanguage :: Text
+  , cpeSoftwareEdition :: Text
+  , cpeTargetSoftware :: Text
+  , cpeTargetHardware :: Text
+  , cpeOther :: Text
+  } deriving (Show)
+
+type CVEID = Text
+type CVEIndex = Map ProductID [(VersionMatcher, [CVEID])]
+
+eitherToParser :: Either String a -> Parser a
+eitherToParser (Left e)  = fail e
+eitherToParser (Right a) = pure a
+
+cveIDNumbers :: Text -> Either String (Int, Int)
+cveIDNumbers rest0 = do
+  rest1 <- note "invalid cve id" $ T.stripPrefix "CVE-" rest0
+  (year, rest2) <- decimal rest1
+  rest3 <- note "invalid cve id" $ T.stripPrefix "-" rest2
+  (subid, rest4) <- decimal rest3
+  guard $ T.null rest4
+  pure (year, subid)
+
+parseDescriptions :: Object -> Parser Text
+parseDescriptions o = do
+  dData <- o .: "description_data"
+  descriptions <- fmap concat $ sequence $ flip map dData $ \dDatum -> do
+    value <- dDatum .: "value"
+    lang :: Text <- dDatum .: "lang"
+    pure $ case lang of
+      "en" -> [value]
+      _    -> []
+  case descriptions of
+    [d] -> pure d
+    -- []  -> pure ""
+    _   -> fail "multiple english descriptions"
+
+foobar :: (FromJSON a) => [a] -> (a -> Parser [b]) -> Parser [b]
+foobar l f = fmap concat $ sequence $ map f l
+
+parseAffects :: Object -> Parser (Map ProductID [VersionMatcher])
+parseAffects o = do
+  vendor <- o .: "vendor"
+  vendorData <- vendor .: "vendor_data"
+  fmap (M.fromListWith (<>) . concat) $ sequence $ flip map vendorData $ \v -> do
+    product <- v .: "product"
+    productData <- product .: "product_data"
+    sequence $ flip map productData $ \p -> do
+      productID <- p .: "product_name"
+      version <- p .: "version"
+      versionData <- version .: "version_data"
+      matchers <- sequence $ flip map versionData $ \ver -> do
+        value <- ver .: "version_value"
+        affected :: Text <- ver .: "version_affected"
+        case affected of
+          "="  -> pure $ FuzzyMatcher value
+          "<=" -> pure $ RangeMatcher Unbounded (Including value)
+          _    -> fail $ "unknown version comparator: " <> show affected
+      pure (productID, matchers)
+
+instance FromJSON CVE where
+  parseJSON = withObject "CVE" $ \o -> do
+    cve <- o .: "cve"
+    cfgs <- o .: "configurations"
+    cveCPEs <- parseConfigurations cfgs
+    meta <- cve .: "CVE_data_meta"
+    cveID <- meta .: "ID"
+    cvePublished <- o .: "publishedDate"
+    cveLastModified <- o .: "lastModifiedDate"
+    (cveYear, cveSubID) <- eitherToParser $ cveIDNumbers cveID
+    description <- cve .: "description"
+    cveDescriptions <- parseDescriptions description
+    affects <- cve .: "affects"
+    cveAffects <- parseAffects affects
+    pure CVE{..}
+
+splitCPE :: Text -> [Text]
+splitCPE = map (T.replace "\a" ":") . T.splitOn ":" . T.replace "\\:" "\a"
+
+instance FromJSON CPE where
+  parseJSON = withText "CPE" $ \t -> do
+    case splitCPE t of
+      [ "cpe", "2.3", cpePart, cpeVendor, cpeProduct, cpeVersion, cpeUpdate
+        , cpeEdition, cpeLanguage, cpeSoftwareEdition, cpeTargetSoftware
+        , cpeTargetHardware, cpeOther
+        ] -> pure CPE{..}
+      _ -> fail $ "unparsable CPE: " <> T.unpack t
+
+guardAttr :: (Eq a, FromJSON a, Show a) => Object -> Text -> a -> Parser ()
+guardAttr object attribute expected = do
+  actual <- object .: attribute
+  unless (actual == expected) $ fail
+    $ "unexpected " <> T.unpack attribute
+      <> ", expected " <> show expected
+      <> ", got " <> show actual
+
+-- TODO: Determine how nodes work exactly. What does AND mean and what does
+-- vulnerable: false mean? For now, we assume everything with vulnerable: true
+-- is vulnerable.
+parseNode :: Object -> Parser [CPE]
+parseNode node = do
+  children <- node .:! "children"
+  parseNode' children node
+
+parseNode' :: (Maybe [Object]) -> Object -> Parser [CPE]
+parseNode' Nothing node = do
+  matches <- node .: "cpe_match"
+  fmap concat $ sequence $ flip map matches $ \match -> do
+    vulnerable <- match .: "vulnerable"
+    cpe <- match .: "cpe23Uri"
+    pure $ if vulnerable then [cpe] else []
+
+parseNode' (Just children) _ = do
+  fmap concat $ sequence $ map parseNode children
+
+parseConfigurations :: Object -> Parser [CPE]
+parseConfigurations o = do
+  guardAttr o "CVE_data_version" ("4.0" :: Text)
+  nodes <- o .: "nodes"
+  fmap concat $ sequence $ map parseNode nodes
+
+parseFeed :: BSL.ByteString -> Either Text [CVE]
+parseFeed = bimap T.pack cvefItems . eitherDecode
+
+data CVEFeed = CVEFeed { cvefItems :: [CVE] }
+
+instance FromJSON CVEFeed where
+  parseJSON = withObject "CVEFeed" $ \o -> CVEFeed <$> o .: "CVE_Items"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -8,6 +8,7 @@ module Main where
 import OurPrelude
 
 import Control.Applicative ((<**>))
+import CVE (updateVulnDB)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import DeleteMerged (deleteDone)
@@ -64,14 +65,17 @@ makeOptions Arguments {dry} = do
 
 main :: IO ()
 main = do
-  arguments@Arguments {mode} <- Opt.execParser programInfo
-  options <- makeOptions arguments
-  updates <- T.readFile "packages-to-update.txt"
-  setupNixpkgs options
-  setEnv "PAGER" "" True
-  setEnv "GITHUB_TOKEN" (T.unpack (githubToken options)) True
-  setEnv "GC_INITIAL_HEAP_SIZE" "10g" True
-  case mode of
-    DeleteDone -> deleteDone options
-    Update -> updateAll options updates
-    UpdateMergeBase -> return ()
+  -- This makes it easier to test until the feature is complete. The regular
+  -- main needs a bunch of configuration to exist before it works.
+  updateVulnDB
+  -- arguments@Arguments {mode} <- Opt.execParser programInfo
+  -- options <- makeOptions arguments
+  -- updates <- T.readFile "packages-to-update.txt"
+  -- setupNixpkgs options
+  -- setEnv "PAGER" "" True
+  -- setEnv "GITHUB_TOKEN" (T.unpack (githubToken options)) True
+  -- setEnv "GC_INITIAL_HEAP_SIZE" "10g" True
+  -- case mode of
+  --   DeleteDone -> deleteDone options
+  --   Update -> updateAll options updates
+  --   UpdateMergeBase -> return ()

--- a/src/NVD.hs
+++ b/src/NVD.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module NVD where
+
+import OurPrelude
+
+import Codec.Compression.GZip (decompress)
+import Control.Exception (ioError, try)
+import Crypto.Hash.SHA256 (hashlazy)
+import CVE (CVE, parseFeed)
+import Data.Bifunctor (second)
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Hex (hex, unhex)
+import qualified Data.Text as T
+import Data.Time.Calendar (toGregorian)
+import Data.Time.Clock
+  (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime, nominalDay, utctDay)
+import Data.Time.ISO8601 (parseISO8601)
+import Network.HTTP.Conduit (simpleHttp)
+import System.Directory
+  (XdgDirectory(..), createDirectoryIfMissing, getModificationTime,
+  getXdgDirectory)
+import System.FilePath ((<.>), (</>))
+import System.IO.Error (userError)
+import Utils (ProductID, Version)
+
+-- | Either @recent@, @modified@, or any year since @2002@.
+type FeedID = String
+type Extension = String
+type Timestamp = UTCTime
+type Checksum = BSL.ByteString
+type CompressedFeed = BSL.ByteString
+type MaxAge = NominalDiffTime
+
+data Meta = Meta Timestamp Checksum
+
+feedURL :: FeedID -> Extension -> String
+feedURL feed ext = "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-" <> feed <> ext
+
+throwString :: MonadIO m => String -> m a
+throwString = liftIO . ioError . userError
+
+throwText :: MonadIO m => Text -> m a
+throwText = throwString . T.unpack
+
+allYears :: IO [FeedID]
+allYears = do
+  now <- liftIO getCurrentTime
+  let (year, _, _) = toGregorian $ utctDay now
+  return $ map show [2002..year]
+
+parseMeta :: BSL.ByteString -> Either T.Text Meta
+parseMeta raw = do
+  let splitLine = second BSL.tail . BSL.break (==':') . BSL.takeWhile (/='\r')
+  let fields = map splitLine $ BSL.lines raw
+  lastModifiedDate <- note "no lastModifiedDate in meta" $ lookup "lastModifiedDate" fields
+  sha256 <- note "no sha256 in meta" $ lookup "sha256" fields
+  timestamp <- note "invalid lastModifiedDate in meta" $ parseISO8601 $ BSL.unpack lastModifiedDate
+  checksum <- note "invalid sha256 in meta" $ unhex sha256
+  return $ Meta timestamp checksum
+
+getMeta :: MonadIO m => FeedID -> m Meta
+getMeta feed = do
+  raw <- simpleHttp $ feedURL feed ".meta"
+  either throwText pure $ parseMeta raw
+
+getCVEs :: (ProductID, Version) -> IO [CVE]
+getCVEs (product, version) = do
+  years <- allYears
+  feeds <- sequence $ map (cacheFeed (7 * nominalDay)) years
+  return []
+
+updateVulnDB :: IO ()
+updateVulnDB = do
+  -- This will be enough to develop with.
+  feed <- cacheFeed (99 * nominalDay) "2019"
+  putStrLn $ "loading data"
+  parsed <- either throwText pure $ parseFeed feed
+  print $ head parsed
+  -- putStrLn $ "checking feed cache"
+  -- years <- allYears
+  -- feeds <- sequence $ map (cacheFeed (7 * nominalDay)) years
+  return ()
+
+getCacheFile ::  MonadIO m => FeedID -> m FilePath
+getCacheFile feed = do
+  cacheDir <- liftIO $ getXdgDirectory XdgCache "nixpkgs-update/nvd"
+  liftIO $ createDirectoryIfMissing True cacheDir
+  return $ cacheDir </> feed <.> "json"
+
+cacheFeed :: MonadIO m => MaxAge -> FeedID -> m BSL.ByteString
+cacheFeed maxAge feed = do
+  cacheFile <- getCacheFile feed
+  cacheTime <- liftIO $ try $ getModificationTime cacheFile
+  Meta newestTime expectedChecksum <- getMeta feed
+  let needsUpdate = case cacheTime of
+        Left (_ :: IOError) -> True
+        Right t -> diffUTCTime newestTime t > maxAge
+
+  if needsUpdate
+    then do
+      liftIO $ putStrLn $ "updating feed: " <> feed
+      compressed <- simpleHttp $ feedURL feed ".json.gz"
+      let raw = decompress compressed
+      let actualChecksum = BSL.fromStrict $ hashlazy raw
+      when (actualChecksum /= expectedChecksum) $ throwString $
+        "wrong hash, expected: " <> BSL.unpack (hex expectedChecksum)
+        <> " got: " <> BSL.unpack (hex actualChecksum)
+      liftIO $ BSL.writeFile cacheFile raw
+      return raw
+    else do
+      liftIO $ BSL.readFile cacheFile

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -5,7 +5,10 @@
 
 module Utils
   ( Options(..)
+  , ProductID
   , Version
+  , Boundary(..)
+  , VersionMatcher(..)
   , UpdateEnv(..)
   , setupNixpkgs
   , tRead
@@ -28,20 +31,33 @@ import System.Environment.XDG.BaseDir
 import System.Posix.Directory (createDirectory)
 import System.Posix.Env (getEnv, setEnv)
 import System.Posix.Files
-  ( directoryMode
-  , fileExist
-  , groupModes
-  , otherExecuteMode
-  , otherReadMode
-  , ownerModes
-  )
+  (directoryMode, fileExist, groupModes, otherExecuteMode, otherReadMode,
+  ownerModes)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (FileMode)
 import qualified System.Process.Typed
 
 default (T.Text)
 
+type ProductID = Text
 type Version = Text
+
+-- | The Ord instance is used to sort lists of matchers in order to compare them
+-- as a set, it is not useful for comparing bounds since the ordering of bounds
+-- depends on whether it is a start or end bound.
+data Boundary a
+  = Unbounded
+  | Including a
+  | Excluding a
+  deriving (Eq, Ord, Show)
+
+-- | The Ord instance is used to sort lists of matchers in order to compare them
+-- as a set, it is not useful for comparing versions.
+data VersionMatcher
+  = ExactMatcher Version
+  | FuzzyMatcher Version
+  | RangeMatcher (Boundary Version) (Boundary Version)
+  deriving (Eq, Ord, Show)
 
 data Options =
   Options


### PR DESCRIPTION
So far, I've worked on downloading the feeds and their metadata, decompressing them, checking their checksums and caching them. The `modified` feed contains all CVEs that were changed in the last 8 days in full. For now, we can redownload the other feeds once every 7 days. Once I add a SQLite database, we can update the CVEs individually, so we won't need to download the large feeds at all as long as the modified feed was updated in the last 7 days. That will also eliminate the need for parsing on every invocation.

I've parsed most of the relevant data from the CVE feeds. The current temporary main caches one feed and shows the first parsed CVE. I've also written some basic version matching logic. It shouldn't have any false negatives but it might have a lot of false positives, so it should probably be improved at some point.