### PR TITLE
Finish CVE caching and querying

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,7 @@ let
       binary-orphans = dontCheck super.binary-orphans;
       binary-instances = dontCheck super.binary-instances;
       hpack = dontCheck super.hpack;
+      partial-order = doJailbreak super.partial-order;
     };
     source-overrides = {
     };

--- a/nixpkgs-update.nix
+++ b/nixpkgs-update.nix
@@ -4,7 +4,7 @@
 , neat-interpolation, optparse-applicative, parsec, parsers
 , polysemy, regex-applicative-text, sqlite-simple, stdenv
 , template-haskell, temporary, text, time, transformers
-, typed-process, unix, vector, xdg-basedir, zlib
+, typed-process, unix, vector, versions, xdg-basedir, zlib
 }:
 mkDerivation {
   pname = "nixpkgs-update";
@@ -19,7 +19,7 @@ mkDerivation {
     lifted-base mtl neat-interpolation optparse-applicative parsec
     parsers polysemy regex-applicative-text sqlite-simple
     template-haskell temporary text time transformers typed-process
-    unix vector xdg-basedir zlib
+    unix vector versions xdg-basedir zlib
   ];
   testHaskellDepends = [
     aeson base bytestring conduit containers cryptohash-sha256
@@ -27,7 +27,7 @@ mkDerivation {
     iso8601-time lifted-base mtl neat-interpolation
     optparse-applicative parsec parsers polysemy regex-applicative-text
     sqlite-simple template-haskell temporary text time transformers
-    typed-process unix vector xdg-basedir zlib
+    typed-process unix vector versions xdg-basedir zlib
   ];
   prePatch = "hpack";
   homepage = "https://github.com/ryantm/nixpkgs-update#readme";

--- a/nixpkgs-update.nix
+++ b/nixpkgs-update.nix
@@ -2,9 +2,9 @@
 , cryptohash-sha256, directory, doctest, errors, filepath, github
 , hex, hpack, http-conduit, iso8601-time, lifted-base, mtl
 , neat-interpolation, optparse-applicative, parsec, parsers
-, polysemy, regex-applicative-text, shelly, stdenv
-, template-haskell, text, time, transformers, typed-process, unix
-, vector, xdg-basedir, zlib
+, polysemy, regex-applicative-text, sqlite-simple, stdenv
+, template-haskell, temporary, text, time, transformers
+, typed-process, unix, vector, xdg-basedir, zlib
 }:
 mkDerivation {
   pname = "nixpkgs-update";
@@ -17,16 +17,17 @@ mkDerivation {
     aeson base bytestring conduit containers cryptohash-sha256
     directory errors filepath github hex http-conduit iso8601-time
     lifted-base mtl neat-interpolation optparse-applicative parsec
-    parsers polysemy regex-applicative-text shelly template-haskell
-    text time transformers typed-process unix vector xdg-basedir zlib
+    parsers polysemy regex-applicative-text sqlite-simple
+    template-haskell temporary text time transformers typed-process
+    unix vector xdg-basedir zlib
   ];
   testHaskellDepends = [
     aeson base bytestring conduit containers cryptohash-sha256
     directory doctest errors filepath github hex http-conduit
     iso8601-time lifted-base mtl neat-interpolation
     optparse-applicative parsec parsers polysemy regex-applicative-text
-    shelly template-haskell text time transformers typed-process unix
-    vector xdg-basedir zlib
+    sqlite-simple template-haskell temporary text time transformers
+    typed-process unix vector xdg-basedir zlib
   ];
   prePatch = "hpack";
   homepage = "https://github.com/ryantm/nixpkgs-update#readme";

--- a/nixpkgs-update.nix
+++ b/nixpkgs-update.nix
@@ -2,8 +2,8 @@
 , cryptohash-sha256, directory, doctest, errors, filepath, github
 , hex, hpack, http-conduit, iso8601-time, lifted-base, mtl
 , neat-interpolation, optparse-applicative, parsec, parsers
-, polysemy, regex-applicative-text, sqlite-simple, stdenv
-, template-haskell, temporary, text, time, transformers
+, partial-order, polysemy, regex-applicative-text, sqlite-simple
+, stdenv, template-haskell, temporary, text, time, transformers
 , typed-process, unix, vector, versions, xdg-basedir, zlib
 }:
 mkDerivation {
@@ -17,7 +17,7 @@ mkDerivation {
     aeson base bytestring conduit containers cryptohash-sha256
     directory errors filepath github hex http-conduit iso8601-time
     lifted-base mtl neat-interpolation optparse-applicative parsec
-    parsers polysemy regex-applicative-text sqlite-simple
+    parsers partial-order polysemy regex-applicative-text sqlite-simple
     template-haskell temporary text time transformers typed-process
     unix vector versions xdg-basedir zlib
   ];
@@ -25,9 +25,10 @@ mkDerivation {
     aeson base bytestring conduit containers cryptohash-sha256
     directory doctest errors filepath github hex http-conduit
     iso8601-time lifted-base mtl neat-interpolation
-    optparse-applicative parsec parsers polysemy regex-applicative-text
-    sqlite-simple template-haskell temporary text time transformers
-    typed-process unix vector versions xdg-basedir zlib
+    optparse-applicative parsec parsers partial-order polysemy
+    regex-applicative-text sqlite-simple template-haskell temporary
+    text time transformers typed-process unix vector versions
+    xdg-basedir zlib
   ];
   prePatch = "hpack";
   homepage = "https://github.com/ryantm/nixpkgs-update#readme";

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ dependencies:
   - polysemy
   - polysemy-plugin
   - regex-applicative-text
+  - sqlite-simple
   - template-haskell
   - text
   - time >= 1.8 && < 1.10

--- a/package.yaml
+++ b/package.yaml
@@ -61,6 +61,7 @@ dependencies:
   - typed-process
   - unix
   - vector
+  - versions
   - xdg-basedir
   - temporary
   - zlib

--- a/package.yaml
+++ b/package.yaml
@@ -50,11 +50,13 @@ dependencies:
   - optparse-applicative
   - parsec
   - parsers
+  - partial-order
   - polysemy
   - polysemy-plugin
   - regex-applicative-text
   - sqlite-simple
   - template-haskell
+  - temporary
   - text
   - time >= 1.8 && < 1.10
   - transformers
@@ -63,7 +65,6 @@ dependencies:
   - vector
   - versions
   - xdg-basedir
-  - temporary
   - zlib
 
 executables:

--- a/src/CVE.hs
+++ b/src/CVE.hs
@@ -208,9 +208,9 @@ guardAttr object attribute expected = do
   actual <- object .: attribute
   unless (actual == expected) $
     fail $
-    "unexpected " <> T.unpack attribute <> ", expected " <> show expected <>
-    ", got " <>
-    show actual
+    "unexpected " <>
+    T.unpack attribute <>
+    ", expected " <> show expected <> ", got " <> show actual
 
 -- Because complex boolean formulas can't be used to determine if a single
 -- product/version is vulnerable, we simply use all leaves marked vulnerable.

--- a/src/CVE.hs
+++ b/src/CVE.hs
@@ -4,7 +4,8 @@
 
 module CVE
   ( parseFeed
-  , CVE
+  , CVE(..)
+  , cveMatcherList
   ) where
 
 import OurPrelude
@@ -12,30 +13,38 @@ import OurPrelude
 import Data.Aeson
   ( FromJSON
   , Object
+  , (.!=)
   , (.:)
   , (.:!)
   , eitherDecode
   , parseJSON
   , withObject
-  , withText
   )
-import Data.Aeson.Types (Parser)
-import Data.Bifunctor (bimap)
-import qualified Data.ByteString.Lazy.Char8 as BSL
+import Data.Aeson.Types (Parser, prependFailure)
+import Data.Bifunctor (bimap, second)
+import Data.List (intercalate)
 import Data.Map (Map)
-import qualified Data.Map as M
-import qualified Data.Text as T
+import Data.Set (Set)
 import Data.Text.Read (decimal)
 import Data.Time.Clock (UTCTime)
+import Database.SQLite.Simple (FromRow, SQLData, ToRow, field, fromRow, toRow)
+
 import Utils (Boundary(..), ProductID, VersionMatcher(..))
+
+import qualified Data.ByteString.Lazy.Char8 as BSL
+import qualified Data.Map as M
+import qualified Data.Set as S
+import qualified Data.Text as T
+
+type CVEID = Text
 
 data CVE =
   CVE
-    { cveID :: Text
+    { cveID :: CVEID
     , cveYear :: Int
     , cveSubID :: Int
-    , cveAffects :: Map ProductID [VersionMatcher]
-    , cveDescriptions :: Text
+    , cveMatchers :: Map ProductID (Set VersionMatcher)
+    , cveDescription :: Text
     , cveCPEs :: [CPE]
     , cvePublished :: UTCTime
     , cveLastModified :: UTCTime
@@ -44,22 +53,71 @@ data CVE =
 
 data CPE =
   CPE
-    { cpePart :: Text
-    , cpeVendor :: Text
-    , cpeProduct :: Text
-    , cpeVersion :: Text
-    , cpeUpdate :: Text
-    , cpeEdition :: Text
-    , cpeLanguage :: Text
-    , cpeSoftwareEdition :: Text
-    , cpeTargetSoftware :: Text
-    , cpeTargetHardware :: Text
-    , cpeOther :: Text
+    { cpeVulnerable :: Bool
+    , cpePart :: Maybe Text
+    , cpeVendor :: Maybe Text
+    , cpeProduct :: Maybe Text
+    , cpeVersion :: Maybe Text
+    , cpeUpdate :: Maybe Text
+    , cpeEdition :: Maybe Text
+    , cpeLanguage :: Maybe Text
+    , cpeSoftwareEdition :: Maybe Text
+    , cpeTargetSoftware :: Maybe Text
+    , cpeTargetHardware :: Maybe Text
+    , cpeOther :: Maybe Text
+    , cpeMatcher :: Maybe VersionMatcher
     }
-  deriving (Show)
 
--- type CVEID = Text
---type CVEIndex = Map ProductID [(VersionMatcher, [CVEID])]
+data MatcherRow =
+  MatcherRow CVEID ProductID VersionMatcher
+
+instance ToRow MatcherRow where
+  toRow (MatcherRow cveID productID matcher) = toRow (cveID, productID, matcher)
+
+instance FromRow MatcherRow where
+  fromRow = MatcherRow <$> field <*> field <*> field
+
+cveMatcherList :: CVE -> [MatcherRow]
+cveMatcherList CVE {cveID, cveMatchers} = do
+  (productID, matchers) <- M.assocs cveMatchers
+  matcher <- S.elems matchers
+  return $ MatcherRow cveID productID matcher
+
+instance Show CPE where
+  show CPE { cpePart
+           , cpeVendor
+           , cpeProduct
+           , cpeVersion
+           , cpeUpdate
+           , cpeEdition
+           , cpeLanguage
+           , cpeSoftwareEdition
+           , cpeTargetSoftware
+           , cpeTargetHardware
+           , cpeOther
+           , cpeMatcher
+           } =
+    "CPE {" <>
+    (intercalate ", " . concat)
+      [ cpeField "part" cpePart
+      , cpeField "vendor" cpeVendor
+      , cpeField "product" cpeProduct
+      , cpeField "version" cpeVersion
+      , cpeField "update" cpeUpdate
+      , cpeField "edition" cpeEdition
+      , cpeField "language" cpeLanguage
+      , cpeField "softwareEdition" cpeSoftwareEdition
+      , cpeField "targetSoftware" cpeTargetSoftware
+      , cpeField "targetHardware" cpeTargetHardware
+      , cpeField "other" cpeOther
+      , cpeField "matcher" cpeMatcher
+      ] <>
+    "}"
+    where
+      cpeField :: Show a => String -> Maybe a -> [String]
+      cpeField _ Nothing = []
+      cpeField name (Just value) = [name <> " = " <> show value]
+
 eitherToParser :: Either String a -> Parser a
 eitherToParser (Left e) = fail e
 eitherToParser (Right a) = pure a
@@ -73,8 +131,8 @@ cveIDNumbers rest0 = do
   guard $ T.null rest4
   pure (year, subid)
 
-parseDescriptions :: Object -> Parser Text
-parseDescriptions o = do
+parseDescription :: Object -> Parser Text
+parseDescription o = do
   dData <- o .: "description_data"
   descriptions <-
     fmap concat $
@@ -86,28 +144,24 @@ parseDescriptions o = do
         case lang of
           "en" -> [value]
           _ -> []
-  case descriptions of
-    [d] -> pure d
-    -- []  -> pure ""
-    _ -> fail "multiple english descriptions"
+  pure $ T.intercalate "\n\n" descriptions
 
--- foobar :: (FromJSON a) => [a] -> (a -> Parser [b]) -> Parser [b]
--- foobar l f = fmap concat $ sequence $ map f l
-parseAffects :: Object -> Parser (Map ProductID [VersionMatcher])
+parseAffects :: Object -> Parser (Map ProductID (Set VersionMatcher))
 parseAffects o = do
   vendor <- o .: "vendor"
   vendorData <- vendor .: "vendor_data"
-  fmap (M.fromListWith (<>) . concat) $
+  fmap (M.fromListWith S.union . concat) $
     sequence $
     flip map vendorData $ \v -> do
-      productPart <- v .: "product"
-      productData <- productPart .: "product_data"
+      product_ <- v .: "product"
+      productData <- product_ .: "product_data"
       sequence $
         flip map productData $ \p -> do
           productID <- p .: "product_name"
           version <- p .: "version"
           versionData <- version .: "version_data"
           matchers <-
+            fmap S.fromList $
             sequence $
             flip map versionData $ \ver -> do
               value <- ver .: "version_value"
@@ -118,31 +172,86 @@ parseAffects o = do
                 _ -> fail $ "unknown version comparator: " <> show affected
           pure (productID, matchers)
 
+-- TODO: We ignore update, edition and softwareEdition for now, but they might
+-- be relevant.
+cpeToMatcher :: CPE -> Map ProductID (Set VersionMatcher)
+cpeToMatcher CPE {cpeProduct = Just p, cpeVersion = Just v, cpeMatcher = Just m} =
+  M.singleton p $ S.fromList [FuzzyMatcher v, m]
+cpeToMatcher CPE {cpeProduct = Just p, cpeVersion = Just v} =
+  M.singleton p $ S.fromList [FuzzyMatcher v]
+cpeToMatcher CPE {cpeProduct = Just p, cpeMatcher = Just m} =
+  M.singleton p $ S.fromList [m]
+cpeToMatcher _ = M.empty
+
+cpeMatchers :: [CPE] -> Map ProductID (Set VersionMatcher)
+cpeMatchers = M.unionsWith S.union . map cpeToMatcher
+
 instance FromJSON CVE where
   parseJSON =
     withObject "CVE" $ \o -> do
       cve <- o .: "cve"
-      cfgs <- o .: "configurations"
-      cveCPEs <- parseConfigurations cfgs
       meta <- cve .: "CVE_data_meta"
       cveID <- meta .: "ID"
-      cvePublished <- o .: "publishedDate"
-      cveLastModified <- o .: "lastModifiedDate"
-      (cveYear, cveSubID) <- eitherToParser $ cveIDNumbers cveID
-      description <- cve .: "description"
-      cveDescriptions <- parseDescriptions description
-      affects <- cve .: "affects"
-      cveAffects <- parseAffects affects
-      pure CVE {..}
+      prependFailure (T.unpack cveID <> ": ") $ do
+        cfgs <- o .: "configurations"
+        cveCPEs <- parseConfigurations cfgs
+        cvePublished <- o .: "publishedDate"
+        cveLastModified <- o .: "lastModifiedDate"
+        (cveYear, cveSubID) <- eitherToParser $ cveIDNumbers cveID
+        description <- cve .: "description"
+        cveDescription <- parseDescription description
+        affects <- cve .: "affects"
+        affectMatchers <- parseAffects affects
+        let cveMatchers =
+              M.unionWith S.union affectMatchers (cpeMatchers cveCPEs)
+        pure CVE {..}
 
-splitCPE :: Text -> [Text]
-splitCPE = map (T.replace "\a" ":") . T.splitOn ":" . T.replace "\\:" "\a"
+instance ToRow CVE where
+  toRow CVE {cveID, cveDescription, cvePublished, cveLastModified} =
+    toRow (cveID, cveDescription, cvePublished, cveLastModified)
+
+instance FromRow CVE where
+  fromRow = do
+    cveID <- field
+    cveDescription <- field
+    cvePublished <- field
+    cveLastModified <- field
+    pure CVE {..}
+
+splitCPE :: Text -> [Maybe Text]
+splitCPE =
+  map (toMaybe . T.replace "\a" ":") . T.splitOn ":" . T.replace "\\:" "\a"
+  where
+    toMaybe "*" = Nothing
+    toMaybe x = Just x
 
 instance FromJSON CPE where
   parseJSON =
-    withText "CPE" $ \t -> do
+    withObject "CPE" $ \o -> do
+      t <- o .: "cpe23Uri"
+      cpeVulnerable <- o .: "vulnerable"
+      vStartIncluding <- o .:! "versionStartIncluding"
+      vEndIncluding <- o .:! "versionEndIncluding"
+      vStartExcluding <- o .:! "versionStartExcluding"
+      vEndExcluding <- o .:! "versionEndExcluding"
+      startBoundary <-
+        case (vStartIncluding, vStartExcluding) of
+          (Nothing, Nothing) -> pure Unbounded
+          (Just start, Nothing) -> pure (Including start)
+          (Nothing, Just start) -> pure (Including start)
+          (Just _, Just _) -> fail "multiple starts"
+      endBoundary <-
+        case (vEndIncluding, vEndExcluding) of
+          (Nothing, Nothing) -> pure Unbounded
+          (Just end, Nothing) -> pure (Including end)
+          (Nothing, Just end) -> pure (Including end)
+          (Just _, Just _) -> fail "multiple ends"
+      let cpeMatcher =
+            case (startBoundary, endBoundary) of
+              (Unbounded, Unbounded) -> Nothing
+              (start, end) -> Just (RangeMatcher start end)
       case splitCPE t of
-        ["cpe", "2.3", cpePart, cpeVendor, cpeProduct, cpeVersion, cpeUpdate, cpeEdition, cpeLanguage, cpeSoftwareEdition, cpeTargetSoftware, cpeTargetHardware, cpeOther] ->
+        [Just "cpe", Just "2.3", cpePart, cpeVendor, cpeProduct, cpeVersion, cpeUpdate, cpeEdition, cpeLanguage, cpeSoftwareEdition, cpeTargetSoftware, cpeTargetHardware, cpeOther] ->
           pure CPE {..}
         _ -> fail $ "unparsable CPE: " <> T.unpack t
 
@@ -151,9 +260,9 @@ guardAttr object attribute expected = do
   actual <- object .: attribute
   unless (actual == expected) $
     fail $
-    "unexpected " <>
-    T.unpack attribute <>
-    ", expected " <> show expected <> ", got " <> show actual
+    "unexpected " <> T.unpack attribute <> ", expected " <> show expected <>
+    ", got " <>
+    show actual
 
 -- TODO: Determine how nodes work exactly. What does AND mean and what does
 -- vulnerable: false mean? For now, we assume everything with vulnerable: true
@@ -165,16 +274,8 @@ parseNode node = do
 
 parseNode' :: (Maybe [Object]) -> Object -> Parser [CPE]
 parseNode' Nothing node = do
-  matches <- node .: "cpe_match"
-  fmap concat $
-    sequence $
-    flip map matches $ \match -> do
-      vulnerable <- match .: "vulnerable"
-      cpe <- match .: "cpe23Uri"
-      pure $
-        if vulnerable
-          then [cpe]
-          else []
+  matches <- node .:! "cpe_match" .!= []
+  pure $ filter cpeVulnerable matches
 parseNode' (Just children) _ = do
   fmap concat $ sequence $ map parseNode children
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,7 +11,7 @@ import Control.Applicative ((<**>))
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import DeleteMerged (deleteDone)
-import NVD (updateVulnDB)
+import NVD (withVulnDB)
 import qualified Nix
 import qualified Options.Applicative as O
 import System.Posix.Env (setEnv)
@@ -66,8 +66,7 @@ programInfo :: O.ParserInfo Command
 programInfo =
   O.info
     (commandParser <**> O.helper)
-    (O.fullDesc <>
-     O.progDesc "Update packages in the Nixpkgs repository" <>
+    (O.fullDesc <> O.progDesc "Update packages in the Nixpkgs repository" <>
      O.header "nixpkgs-update")
 
 getGithubToken :: IO Text
@@ -95,4 +94,4 @@ main = do
       case v of
         Left t -> T.putStrLn ("error:" <> t)
         Right t -> T.putStrLn t
-    UpdateVulnDB -> updateVulnDB
+    UpdateVulnDB -> withVulnDB $ \_conn -> pure ()

--- a/src/NVD.hs
+++ b/src/NVD.hs
@@ -272,8 +272,9 @@ withVulnDB action = do
   rebuild <- needsRebuild
   when rebuild rebuildDB
   withDB $ \conn -> do
-    unless rebuild $ downloadFeed conn (0.25 * nominalDay) "modified"
-    markUpdated conn
+    unless rebuild $ do
+      downloadFeed conn (0.25 * nominalDay) "modified"
+      markUpdated conn
     action conn
 
 -- | Update a feed if it's older than a maximum age and return the contents as

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -72,8 +72,7 @@ data Boundary a
 -- | The Ord instance is used to sort lists of matchers in order to compare them
 -- as a set, it is not useful for comparing versions.
 data VersionMatcher
-  = ExactMatcher Version
-  | FuzzyMatcher Version
+  = SingleMatcher Version
   | RangeMatcher (Boundary Version) (Boundary Version)
   deriving (Eq, Ord, Show, Read)
 

--- a/src/Version.hs
+++ b/src/Version.hs
@@ -7,9 +7,8 @@ module Version
 
 import OurPrelude
 
-import Data.List (unfoldr)
 import qualified Data.Text as T
-import Data.Text.Read (decimal)
+import Data.Versions (Versioning, prettyV, versioning)
 import Utils
 
 notElemOf :: (Eq a, Foldable t) => t a -> a -> Bool
@@ -90,30 +89,38 @@ assertCompatibleWithPathPin ue attrPath =
        (versionCompatibleWithPathPin attrPath (oldVersion ue) &&
         versionIncompatibleWithPathPin attrPath (newVersion ue)))
 
--- | Split a version in a list of dot-separated numbers and drop the unparsable
--- part at the end.
-versionSplit :: Version -> [Int]
-versionSplit = unfoldr getVersionPart
-  where
-    getVersionPart t0 = do
-      (i, t1) <- hush $ decimal t0
-      t2 <- T.stripPrefix "." t1
-      return (i, t2)
+data ParsedVersion
+  = Unparsable Text
+  | Parsed Versioning
+  deriving (Show, Eq)
+
+-- TODO: Comparing unparsable versions by text is not acceptable. Better parsing
+-- is needed.
+instance Ord ParsedVersion where
+  compare (Unparsable a) (Unparsable b) = compare a b
+  compare (Parsed a) (Unparsable b) = compare (prettyV a) b
+  compare (Unparsable a) (Parsed b) = compare a (prettyV b)
+  compare (Parsed a) (Parsed b) = compare a b
+
+parseVersion :: Version -> ParsedVersion
+parseVersion v =
+  case versioning v of
+    Left _ -> Unparsable v
+    Right v' -> Parsed v'
 
 matchUpperBound :: Boundary Version -> Version -> Bool
-matchUpperBound Unbounded     _ = True
-matchUpperBound (Including b) v = versionSplit v <= versionSplit b
-matchUpperBound (Excluding b) v = versionSplit v <  versionSplit b
+matchUpperBound Unbounded _ = True
+matchUpperBound (Including b) v = parseVersion v <= parseVersion b
+matchUpperBound (Excluding b) v = parseVersion v < parseVersion b
 
 matchLowerBound :: Boundary Version -> Version -> Bool
-matchLowerBound Unbounded     _ = True
-matchLowerBound (Including b) v = versionSplit b <= versionSplit v
-matchLowerBound (Excluding b) v = versionSplit b <  versionSplit v
+matchLowerBound Unbounded _ = True
+matchLowerBound (Including b) v = parseVersion b <= parseVersion v
+matchLowerBound (Excluding b) v = parseVersion b < parseVersion v
 
 -- | A basic method of matching versions with CVE version matchers. Can be
 -- improved upon if there are too many false positives.
 matchVersion :: VersionMatcher -> Version -> Bool
-matchVersion (ExactMatcher v) v' = v == v'
-matchVersion (FuzzyMatcher v) v' = versionSplit v == versionSplit v'
-matchVersion (RangeMatcher lowerBound upperBound) v
-  = matchLowerBound lowerBound v && matchUpperBound upperBound v
+matchVersion (SingleMatcher v) v' = parseVersion v == parseVersion v'
+matchVersion (RangeMatcher lowerBound upperBound) v =
+  matchLowerBound lowerBound v && matchUpperBound upperBound v


### PR DESCRIPTION
You can use `withVulnDB $ \conn -> do ...` to open a connection to an updated database, this will take a few minutes and several gigabytes of memory to populate when run for the first time. After that, as long as the database is opened/updated at least once every 7 days, updating will only take a few seconds. You can use `getCVEs conn productID version` to get a list of CVEs that version of the product is vulnerable for.