### PR TITLE
Bugfix: overlays should be ignored when importing/running NixPkgs

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -41,7 +41,7 @@ import System.Exit
 import Text.Parsec (parse)
 import Text.Parser.Combinators
 import Text.Parser.Token
-import Utils (UpdateEnv (..), nixBuildOptions, overwriteErrorT, srcOrMain)
+import Utils (UpdateEnv (..), nixBuildOptions, nixCommonOptions, overwriteErrorT, srcOrMain)
 import Prelude hiding (log)
 
 data Env = Env [(String, String)]
@@ -92,15 +92,14 @@ lookupAttrPath :: MonadIO m => UpdateEnv -> ExceptT Text m Text
 lookupAttrPath updateEnv =
   proc
     "nix-env"
-    [ "-qa",
-      (packageName updateEnv <> "-" <> oldVersion updateEnv) & T.unpack,
-      "-f",
-      ".",
-      "--attr-path",
-      "--arg",
-      "config",
-      "{ allowBroken = true; allowUnfree = true; allowAliases = false; }"
-    ]
+    ( [ "-qa",
+        (packageName updateEnv <> "-" <> oldVersion updateEnv) & T.unpack,
+        "-f",
+        ".",
+        "--attr-path"
+      ]
+        <> nixCommonOptions
+    )
     & ourReadProcessInterleaved_
     & fmapRT (T.lines >>> head >>> T.words >>> head)
     & overwriteErrorT "nix-env -q failed to find package name with old version "

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -21,6 +21,7 @@ module Utils
     srcOrMain,
     prTitle,
     nixBuildOptions,
+    nixCommonOptions,
   )
 where
 
@@ -216,6 +217,16 @@ tRead = read . T.unpack
 srcOrMain :: MonadIO m => (Text -> ExceptT Text m a) -> Text -> ExceptT Text m a
 srcOrMain et attrPath = et (attrPath <> ".src") <|> et attrPath
 
+nixCommonOptions :: [String]
+nixCommonOptions =
+  [ "--arg",
+    "config",
+    "{ allowBroken = true; allowUnfree = true; allowAliases = false; }",
+    "--arg",
+    "overlays",
+    "[ ]"
+  ]
+
 nixBuildOptions :: [String]
 nixBuildOptions =
   [ "--option",
@@ -223,8 +234,6 @@ nixBuildOptions =
     "true",
     "--option",
     "restrict-eval",
-    "true",
-    "--arg",
-    "config",
-    "{ allowBroken = true; allowUnfree = true; allowAliases = false; }"
+    "true"
   ]
+    <> nixCommonOptions


### PR DESCRIPTION
Normally this is run on a server without any overlays, but if a user is
developing/testing it locally there may be some which the bot is not able to
understand (e.g, Nix User Repository or emacs-overlay imports).

When NixPkgs is imported, if we explicitly pass overlays as an empty list, it
will not search the environment or the user's home directory for overlays in
impure.nix:
https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/impure.nix