### PR TITLE
Don't swallow error msg on nix-env failures

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -103,7 +103,6 @@ lookupAttrPath updateEnv =
     ]
     & ourReadProcessInterleaved_
     & fmapRT (T.lines >>> head >>> T.words >>> head)
-    & overwriteErrorT "nix-env -q failed to find package name with old version "
 
 getDerivationFile :: MonadIO m => Text -> ExceptT Text m FilePath
 getDerivationFile attrPath =


### PR DESCRIPTION
Debatable change, depending on how big the logfiles are and how you have your
server setup for rotation, so I sent it in its own PR.

When debugging https://github.com/ryantm/nixpkgs-update/issues/137#issuecomment-587161413
and #143, it would be been significantly faster if I had the error msg coming
out of nix-env.

For example, this immediately clues me into what's going on:

```
2020-02-17T22:54:02 mdds 1.5.0 -> 1.6
2020-02-17T22:54:11 FAIL Received ExitFailure 1 when running
Raw command: nix-env -qa mdds-1.5.0 -f . --attr-path --arg config "{ allowBroken = true; allowUnfree = true; allowAliases = false; }"
Standard output:

error: attribute 'emacsPackagesGen' missing, at /nix/store/sp89k0fwkdzm6wwxqsc6iymhvh1l2wxr-source/elisp.nix:38:19

2020-02-17T22:54:12 ups.sh finished
```

whereas this is not so helpful, particularly when cd'ing to that dir and
manually running the same cmd appears to work just fine:

```
2020-02-17T22:36:02 New run of ups.sh
2020-02-17T22:36:02 mdds 1.5.0 -> 1.6.0
2020-02-17T22:36:11 FAIL nix-env -q failed to find package with old version
2020-02-17T22:36:12 mdds 1.5.0 -> 1.6
2020-02-17T22:36:21 FAIL nix-env -q failed to find package with old version
2020-02-17T22:36:22 ups.sh finished
```