### PR TITLE
Refactor the update function to make it easier to add rewriters; add rewriter for meta.homepage

### DIFF
--- a/src/Rewrite.hs
+++ b/src/Rewrite.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Rewriters
-  ( RewriteArgs (..),
-    rewriteVersion,
-    rewriteQuotedUrls,
+module Rewrite
+  ( Args (..),
+    version,
+    quotedUrls,
   )
 where
 
@@ -24,8 +24,8 @@ import qualified Utils
 -- really easy to unit test, so we should setup a rewriters test framework that
 -- uses some mock.nix files and rewrites them, then asserts the expected diff.
 
-data RewriteArgs
-  = RewriteArgs
+data Args
+  = Args
       { updateEnv :: Utils.UpdateEnv,
         attrPath :: Text,
         derivationFile :: FilePath
@@ -33,8 +33,8 @@ data RewriteArgs
 
 --------------------------------------------------------------------------------
 -- The canonical updater: updates the src attribute and recomputes the sha256
-rewriteVersion :: MonadIO m => RewriteArgs -> ExceptT Text m ()
-rewriteVersion (RewriteArgs env attrPth drvFile) = do
+version :: MonadIO m => Args -> ExceptT Text m ()
+version (Args env attrPth drvFile) = do
   oldHash <- Nix.getOldHash attrPth
   -- Change the actual version
   lift $ File.replace (Utils.oldVersion env) (Utils.newVersion env) drvFile
@@ -45,8 +45,8 @@ rewriteVersion (RewriteArgs env attrPth drvFile) = do
 --------------------------------------------------------------------------------
 -- Rewrite meta.homepage (and eventually other URLs) to be quoted if not
 -- already, as per https://github.com/NixOS/rfcs/pull/45
-rewriteQuotedUrls :: MonadIO m => RewriteArgs -> ExceptT Text m ()
-rewriteQuotedUrls (RewriteArgs _ attrPth drvFile) = do
+quotedUrls :: MonadIO m => Args -> ExceptT Text m ()
+quotedUrls (Args _ attrPth drvFile) = do
   homepage <- Nix.getHomepage attrPth
   contents <- liftIO $ T.readFile drvFile
   -- The homepage that comes out of nix-env is *always* quoted by the nix eval,

--- a/src/Rewriters.hs
+++ b/src/Rewriters.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Rewriters
+  ( RewriteArgs (..),
+    rewriteVersion,
+    rewriteQuotedUrls,
+  )
+where
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified File
+import qualified Nix
+import OurPrelude
+import qualified Utils
+  ( UpdateEnv (..),
+  )
+
+-- This module contains rewrite functions that make some modification to the
+-- nix derivation. These are in the IO monad so that they can do things like
+-- re-run nix-build to recompute hashes, but morally they should just stick to
+-- editing the derivationFile for their one stated purpose.
+-- TODO: This is a work in progress. The rewriteQuotedUrls rewriter should be
+-- really easy to unit test, so we should setup a rewriters test framework that
+-- uses some mock.nix files and rewrites them, then asserts the expected diff.
+
+data RewriteArgs
+  = RewriteArgs
+      { updateEnv :: Utils.UpdateEnv,
+        attrPath :: Text,
+        derivationFile :: FilePath
+      }
+
+--------------------------------------------------------------------------------
+-- The canonical updater: updates the src attribute and recomputes the sha256
+rewriteVersion :: MonadIO m => RewriteArgs -> ExceptT Text m ()
+rewriteVersion (RewriteArgs env attrPth drvFile) = do
+  oldHash <- Nix.getOldHash attrPth
+  -- Change the actual version
+  lift $ File.replace (Utils.oldVersion env) (Utils.newVersion env) drvFile
+  lift $ File.replace oldHash Nix.sha256Zero drvFile
+  newHash <- Nix.getHashFromBuild attrPth
+  lift $ File.replace Nix.sha256Zero newHash drvFile
+
+--------------------------------------------------------------------------------
+-- Rewrite meta.homepage (and eventually other URLs) to be quoted if not
+-- already, as per https://github.com/NixOS/rfcs/pull/45
+rewriteQuotedUrls :: MonadIO m => RewriteArgs -> ExceptT Text m ()
+rewriteQuotedUrls (RewriteArgs _ attrPth drvFile) = do
+  homepage <- Nix.getHomepage attrPth
+  contents <- liftIO $ T.readFile drvFile
+  -- The homepage that comes out of nix-env is *always* quoted by the nix eval,
+  -- so we drop the first and last characters. Bit of a hack but it works.
+  let stripped = T.init . T.tail $ homepage
+  unless (T.isInfixOf homepage contents) $
+    File.replace stripped homepage drvFile


### PR DESCRIPTION
Per discussion, we are interested in evolving `nixpkgs-update` to be a bot that
slowly cleans up arbitrary bits of "legacy" nix code as part of the standard
package version update process.

This does some refactoring of the main Update function to factor out the existing
version-bumper as a rewrite function, and add a second one for updating
meta.homepage to be quoted (if not done already).