### PR TITLE
Move assertions to prepare for other updaters that can change version

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -9,6 +9,7 @@ module Nix
     lookupAttrPath,
     getDerivationFile,
     getMaintainers,
+    getHash,
     getOldHash,
     getSrcUrl,
     getSrcUrls,

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -19,8 +19,8 @@ module Nix
     getDescription,
     getHomepage,
     cachix,
-    assertOneOrFewerFetcher,
-    assertOneOrFewerHashes,
+    numberOfFetchers,
+    numberOfHashes,
     getHashFromBuild,
     assertOldVersionOn,
     resultLink,
@@ -243,22 +243,10 @@ numberOfFetchers derivationContents =
   where
     countUp x = T.count x derivationContents
 
-assertOneOrFewerFetcher :: MonadIO m => Text -> FilePath -> ExceptT Text m ()
-assertOneOrFewerFetcher derivationContents derivationFile =
-  tryAssert
-    ("More than one fetcher in " <> T.pack derivationFile)
-    (numberOfFetchers derivationContents <= 1)
-
 numberOfHashes :: Text -> Int
 numberOfHashes derivationContents = countUp "sha256 =" + countUp "sha256="
   where
     countUp x = T.count x derivationContents
-
-assertOneOrFewerHashes :: MonadIO m => Text -> FilePath -> ExceptT Text m ()
-assertOneOrFewerHashes derivationContents derivationFile =
-  tryAssert
-    ("More than one hash in " <> T.pack derivationFile)
-    (numberOfHashes derivationContents <= 1)
 
 assertOldVersionOn ::
   MonadIO m => UpdateEnv -> Text -> Text -> ExceptT Text m ()

--- a/src/Rewrite.hs
+++ b/src/Rewrite.hs
@@ -54,6 +54,7 @@ version log (Args env attrPth drvFile drvContents) = do
       _ <- lift $ File.replace (Utils.oldVersion env) (Utils.newVersion env) drvFile
       _ <- lift $ File.replace oldHash Nix.sha256Zero drvFile
       newHash <- Nix.getHashFromBuild attrPth
+      when (oldHash == newHash) $ throwE "Hashes equal; no update necessary"
       _ <- lift $ File.replace Nix.sha256Zero newHash drvFile
       lift $ log "[version]: updated version and sha256"
       return $ Just "Version update"

--- a/src/Rewrite.hs
+++ b/src/Rewrite.hs
@@ -43,20 +43,20 @@ data Args
 --------------------------------------------------------------------------------
 -- The canonical updater: updates the src attribute and recomputes the sha256
 version :: MonadIO m => (Text -> m ()) -> Args -> ExceptT Text m (Maybe Text)
-version log (Args env attrPth drvFile _) = do
+version log (Args env attrPth drvFile drvContents) = do
   lift $ log "[version] started"
-  oldHash <- Nix.getOldHash attrPth
-  oldSrcUrl <- Nix.getSrcUrl attrPth
-  -- Change the actual version
-  _ <- lift $ File.replace (Utils.oldVersion env) (Utils.newVersion env) drvFile
-  newSrcUrl <- Nix.getSrcUrl attrPth
-  when (oldSrcUrl == newSrcUrl) $ throwE "Source url did not change. "
-  _ <- lift $ File.replace oldHash Nix.sha256Zero drvFile
-  newHash <- Nix.getHashFromBuild attrPth
-  tryAssert "Hashes equal; no update necessary" (oldHash /= newHash)
-  _ <- lift $ File.replace Nix.sha256Zero newHash drvFile
-  lift $ log "[version]: updated version and sha256"
-  return $ Just "Version update"
+  if Nix.numberOfFetchers drvContents > 1 || Nix.numberOfHashes drvContents > 1
+    then do
+      lift $ log "[version]: generic version rewriter does not support multiple hashes"
+      return Nothing
+    else do
+      oldHash <- Nix.getOldHash attrPth
+      _ <- lift $ File.replace (Utils.oldVersion env) (Utils.newVersion env) drvFile
+      _ <- lift $ File.replace oldHash Nix.sha256Zero drvFile
+      newHash <- Nix.getHashFromBuild attrPth
+      _ <- lift $ File.replace Nix.sha256Zero newHash drvFile
+      lift $ log "[version]: updated version and sha256"
+      return $ Just "Version update"
 
 --------------------------------------------------------------------------------
 -- Rewrite meta.homepage (and eventually other URLs) to be quoted if not

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -225,7 +225,7 @@ updatePackage log updateEnv mergeBaseOutpathsContext =
     lift . log $ "Diff after rewrites::\n" <> diffAfterRewrites
     updatedDerivationContents <- liftIO $ T.readFile derivationFile
     newSrcUrl <- Nix.getSrcUrl attrPath
-    newHash <- Nix.getHashFromBuild attrPath
+    newHash <- Nix.getHash attrPath
     -- Sanity checks to make sure the PR is worth opening
     when (derivationContents == updatedDerivationContents) $ throwE "No rewrites performed on derivation."
     when (oldSrcUrl == newSrcUrl) $ throwE "Source url did not change. "


### PR DESCRIPTION
No functional change intended, but please review carefully, as this is mostly untested!

Previously:

1. The assertion about having a single sha was at the top-level, and
2. The assertion that the rewrite changed something meaningful (src url version,
   output hash) was inlined inside the `version` rewrite rule.

This commit moves the single-sha limitation down into `version`, and moves the
"did we change something meaningful" check out of `version` and into the top-level.

This is a no-op refactoring to prepare for adding other rewrite rules which CAN
process multiple shas, such as update functions for Rust and Go packages. Like
the regular version one, these should still be constrained by the requirement
that they actually make a "real" version bump change, e.g. change the `src` and
`outputHash`.