### PR TITLE
Refactor rewriters to reduce duplication

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -272,7 +272,7 @@ publishPackage log updateEnv oldSrcUrl newSrcUrl attrPath result opDiff msgs = d
         if u == T.empty
           then ""
           else "\n\nmeta.homepage for " <> attrPath <> " is: " <> u
-  let rewriteMessages = foldl (\ms m -> ms <> T.pack "\n- " <> m) "Updates performed:" msgs
+  let rewriteMessages = foldl (\ms m -> ms <> T.pack "\n- " <> m) "\nUpdates performed:" msgs
   releaseUrlMessage <-
     ( do
         msg <- GH.releaseUrl newSrcUrl


### PR DESCRIPTION
This commit moves the meat of the standard `src` and `version` update into a
helper function that can be re-used across the regular version updater and the
Rust package updater.

Since I am soon to add it to a third place for updating Golang packages, which
structurally look a lot like Rust updates, I think it makes sense to move this
to a helper function rather than copy it in a third place.

Also adds a newline in front of the section on `Updates Performed` to make the
PR comment prettier.

All in all, no functional changes intended, just cleanups/prep for more features.