### PR TITLE
Automated updates for buildGoModule packages

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -8,6 +8,7 @@ module Nix
     assertOldVersionOn,
     build,
     cachix,
+    getAttr,
     getDerivationFile,
     getDescription,
     getDrvAttr,
@@ -116,6 +117,13 @@ getDrvAttr :: MonadIO m => Text -> Text -> ExceptT Text m Text
 getDrvAttr drvAttr =
   srcOrMain
     (\attrPath -> nixEvalET (EvalOptions Raw (Env [])) ("pkgs." <> attrPath <> ".drvAttrs." <> drvAttr))
+
+-- Get an attribute that can be evaluated off a derivation, as in:
+-- getAttr "cargoSha256" "ripgrep" -> 0lwz661rbm7kwkd6mallxym1pz8ynda5f03ynjfd16vrazy2dj21
+getAttr :: MonadIO m => Text -> Text -> ExceptT Text m Text
+getAttr attr =
+  srcOrMain
+    (\attrPath -> nixEvalET (EvalOptions Raw (Env [])) (attrPath <> "." <> attr))
 
 getHash :: MonadIO m => Text -> ExceptT Text m Text
 getHash =

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -217,8 +217,9 @@ updatePackage log updateEnv mergeBaseOutpathsContext =
     let rwArgs = Rewrite.Args updateEnv attrPath derivationFile derivationContents
     msg1 <- Rewrite.version log rwArgs
     msg2 <- Rewrite.rustCrateVersion log rwArgs
-    msg3 <- Rewrite.quotedUrls log rwArgs
-    let msgs = catMaybes [msg1, msg2, msg3]
+    msg3 <- Rewrite.golangModuleVersion log rwArgs
+    msg4 <- Rewrite.quotedUrls log rwArgs
+    let msgs = catMaybes [msg1, msg2, msg3, msg4]
     ----------------------------------------------------------------------------
     --
     -- Compute the diff and get updated values


### PR DESCRIPTION
Having merged an update to make go packages passthru the `modSha256` [1], we can
now have `nixpkgs-update` inspect it and make updates, just as it now does for
Rust packages as of [2].

As a slight detail, because the attribute is in `passthru` rather than actually
being available in the derivation, we just do the equivalent of
`nix eval -f . <attrPath>.<attr>` rather than going through the `drvAttrs` as before.

This version has been tested successfully with at least one go update [3], but
not thoroughly vetted. That said, it's essentially identical to the Rust
implementation that has been working well for some time now.

[1] https://github.com/NixOS/nixpkgs/pull/82027
[2] https://github.com/ryantm/nixpkgs-update/pull/156
[3] https://github.com/NixOS/nixpkgs/pull/82465