### PR TITLE
Name workflow "CI" instead of "Test"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: "Test"
+name: "CI"
 on:
   pull_request:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixpkgs-update
 
-[![Build Status](https://github.com/ryantm/nixpkgs-update/workflows/Test/badge.svg)](https://github.com/ryantm/nixpkgs-update/actions)
+[![Build Status](https://github.com/ryantm/nixpkgs-update/workflows/CI/badge.svg)](https://github.com/ryantm/nixpkgs-update/actions)
 [![Patreon](https://img.shields.io/badge/patreon-donate-blue.svg)](https://www.patreon.com/nixpkgsupdate)
 
 > The future is here; let's evenly distribute it!


### PR DESCRIPTION
This looks a little cleaner (`CI/tests` vs. `Test/tests`), and allows us space
to add more parallel workflows like `CI/format`.