### PR TITLE
improve ux for single update case

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,19 +128,18 @@ test a package with one command.
 3. To test your config, try to update a single package, like this:
 
    ```
-   ./result/bin/nixpkgs-update update --dry-run --additional-updates "pkg oldVer newVer update-page"`
+   ./result/bin/nixpkgs-update update "pkg oldVer newVer update-page"`
 
    # Example:
-   ./result/bin/nixpkgs-update update --dry-run --additional-updates "tflint 0.15.0 0.15.1 repology.org"`
+   ./result/bin/nixpkgs-update update "tflint 0.15.0 0.15.1 repology.org"`
    ```
 
    replacing `tflint` with the attribute name of the package you actually want
    to update, and the old version and new version accordingly.
 
-   If this works, you are now setup to hack on `nixpkgs-update`! Since we passed
-   `--dry-run`, it will just print a `diff` of the updated nix expression, then
-   exit. If you run it without `--dry-run`, it will actually send a pull
-   request, which looks like this: https://github.com/NixOS/nixpkgs/pull/82465
+   If this works, you are now setup to hack on `nixpkgs-update`! If
+   you run it with `--pr`, it will actually send a pull request, which
+   looks like this: https://github.com/NixOS/nixpkgs/pull/82465
 
 
 4. If you'd like to send a batch of updates, get a list of outdated packages and

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,15 +23,14 @@ default (T.Text)
 
 data UpdateOptions
   = UpdateOptions
-      { dry :: Bool,
+      { pr :: Bool,
         cachix :: Bool,
-        additionalUpdates :: Text,
         outpaths :: Bool
       }
 
 data Command
   = UpdateList UpdateOptions
-  | Update UpdateOptions
+  | Update UpdateOptions Text
   | DeleteDone
   | Version
   | UpdateVulnDB
@@ -43,14 +42,15 @@ data Command
 updateOptionsParser :: O.Parser UpdateOptions
 updateOptionsParser =
   UpdateOptions
-    <$> O.switch
-      ( O.long "dry-run"
-          <> O.help
-            "Do everything except actually pushing the updates to the remote repository"
-      )
+    <$> O.flag False True (O.long "pr" <> O.help "Make a pull request using Hub.")
     <*> O.flag False True (O.long "cachix" <> O.help "Push changes to Cachix")
-    <*> O.strOption (O.long "additional-updates" <> O.help "A string of updates formatted the same way as packages-to-update.txt" <> O.value "")
     <*> O.flag False True (O.long "outpaths" <> O.help "Calculate outpaths to determine the branch to target")
+
+updateParser :: O.Parser Command
+updateParser =
+  Update
+    <$> updateOptionsParser
+    <*> O.strArgument (O.metavar "UPDATE_INFO" <> O.help "update string of the form: 'pkg oldVer newVer update-page'\n\n example: 'tflint 0.15.0 0.15.1 repology.org'")
 
 commandParser :: O.Parser Command
 commandParser =
@@ -60,7 +60,7 @@ commandParser =
         (O.info (UpdateList <$> updateOptionsParser) (O.progDesc "Update a list of packages"))
         <> O.command
           "update"
-          (O.info (Update <$> updateOptionsParser) (O.progDesc "Update packages"))
+          (O.info (updateParser) (O.progDesc "Update one package"))
         <> O.command
           "delete-done"
           ( O.info
@@ -124,19 +124,19 @@ main = do
       setupNixpkgs token
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
       deleteDone token
-    UpdateList UpdateOptions {dry, cachix, additionalUpdates, outpaths} -> do
+    UpdateList UpdateOptions {pr, cachix, outpaths} -> do
       token <- getGithubToken
       updates <- T.readFile "packages-to-update.txt"
       setupNixpkgs token
       P.setEnv "PAGER" "" True
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
-      updateAll (Options dry token cachix outpaths) (updates <> "\n" <> additionalUpdates)
-    Update UpdateOptions {dry, cachix, additionalUpdates, outpaths} -> do
+      updateAll (Options pr True token cachix outpaths) updates
+    Update UpdateOptions {pr, cachix, outpaths} update -> do
       token <- getGithubToken
       setupNixpkgs token
       P.setEnv "PAGER" "" True
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
-      updateAll (Options dry token cachix outpaths) additionalUpdates
+      updateAll (Options pr False token cachix outpaths) update
     Version -> do
       v <- runExceptT Nix.version
       case v of
@@ -146,17 +146,17 @@ main = do
     CheckAllVulnerable -> do
       setupNixpkgs undefined
       updates <- T.readFile "packages-to-update.txt"
-      cveAll (Options undefined undefined undefined undefined) updates
+      cveAll (Options undefined undefined undefined undefined undefined) updates
     CheckVulnerable productID oldVersion newVersion -> do
       setupNixpkgs undefined
       report <-
         cveReport
-          (UpdateEnv productID oldVersion newVersion Nothing (Options False undefined False False))
+          (UpdateEnv productID oldVersion newVersion Nothing (Options False False undefined False False))
       T.putStrLn report
     SourceGithub -> do
       token <- getGithubToken
       updates <- T.readFile "packages-to-update.txt"
       setupNixpkgs token
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
-      sourceGithubAll (Options False token False False) updates
+      sourceGithubAll (Options False False token False False) updates
     FetchRepology -> Repology.fetch

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,7 +16,7 @@ import OurPrelude
 import qualified Repology
 import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
 import qualified System.Posix.Env as P
-import Update (cveAll, cveReport, sourceGithubAll, updateAll)
+import Update (cveAll, cveReport, sourceGithubAll, updateAll, updatePackage)
 import Utils (Options (..), UpdateEnv (..), getGithubToken, setupNixpkgs)
 
 default (T.Text)
@@ -131,12 +131,15 @@ main = do
       P.setEnv "PAGER" "" True
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
       updateAll (Options pr True token cachix outpaths) updates
-    Update UpdateOptions {pr, cachix, outpaths} update -> do
+    Update UpdateOptions {pr, cachix} update -> do
       token <- getGithubToken
       setupNixpkgs token
       P.setEnv "PAGER" "" True
       P.setEnv "GITHUB_TOKEN" (T.unpack token) True
-      updateAll (Options pr False token cachix outpaths) update
+      result <- updatePackage (Options pr False token cachix False) update
+      case result of
+        Left e -> T.putStrLn e
+        Right () -> T.putStrLn "Done."
     Version -> do
       v <- runExceptT Nix.version
       case v of

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -98,7 +98,7 @@ push updateEnv =
             "origin",
             T.unpack (branchName updateEnv)
           ]
-            ++ ["--dry-run" | dryRun (options updateEnv)]
+            ++ ["--dry-run" | doPR (options updateEnv)]
         )
     )
 

--- a/src/Rewrite.hs
+++ b/src/Rewrite.hs
@@ -2,6 +2,7 @@
 
 module Rewrite
   ( Args (..),
+    runAll,
     golangModuleVersion,
     quotedUrls,
     quotedUrlsET,
@@ -46,6 +47,14 @@ data Args
         derivationFile :: FilePath,
         derivationContents :: Text
       }
+
+runAll :: (Text -> IO ()) -> Args -> ExceptT Text IO [Text]
+runAll log rwArgs = do
+  msg1 <- Rewrite.version log rwArgs
+  msg2 <- Rewrite.rustCrateVersion log rwArgs
+  msg3 <- Rewrite.golangModuleVersion log rwArgs
+  msg4 <- Rewrite.quotedUrlsET log rwArgs
+  return $ catMaybes [msg1, msg2, msg3, msg4]
 
 --------------------------------------------------------------------------------
 -- The canonical updater: updates the src attribute and recomputes the sha256

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -230,11 +230,7 @@ updatePackageBatch log updateEnv mergeBaseOutpathsContext =
     -- that we actually should be touching this file. Get to work processing the
     -- various rewrite functions!
     let rwArgs = Rewrite.Args updateEnv attrPath derivationFile derivationContents
-    msg1 <- Rewrite.version log rwArgs
-    msg2 <- Rewrite.rustCrateVersion log rwArgs
-    msg3 <- Rewrite.golangModuleVersion log rwArgs
-    msg4 <- Rewrite.quotedUrlsET log rwArgs
-    let msgs = catMaybes [msg1, msg2, msg3, msg4]
+    msgs <- Rewrite.runAll log rwArgs
     ----------------------------------------------------------------------------
     --
     -- Compute the diff and get updated values
@@ -555,11 +551,7 @@ updatePackage o updateInfo = do
     -- that we actually should be touching this file. Get to work processing the
     -- various rewrite functions!
     let rwArgs = Rewrite.Args updateEnv attrPath derivationFile derivationContents
-    msg1 <- Rewrite.version log rwArgs
-    msg2 <- Rewrite.rustCrateVersion log rwArgs
-    msg3 <- Rewrite.golangModuleVersion log rwArgs
-    msg4 <- Rewrite.quotedUrlsET log rwArgs
-    let msgs = catMaybes [msg1, msg2, msg3, msg4]
+    msgs <- Rewrite.runAll log rwArgs
     ----------------------------------------------------------------------------
     --
     -- Compute the diff and get updated values

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -103,7 +103,8 @@ instance ToField VersionMatcher where
 
 data Options
   = Options
-      { dryRun :: Bool,
+      { doPR :: Bool,
+        batchUpdate :: Bool,
         githubToken :: Text,
         pushToCachix :: Bool,
         calculateOutpaths :: Bool

--- a/test/RewriteSpec.hs
+++ b/test/RewriteSpec.hs
@@ -23,7 +23,7 @@ spec = do
     it "quotes an unquoted meta.homepage URL" do
       nixQuotedHomepageBad <- T.readFile "test_data/quoted_homepage_bad.nix"
       nixQuotedHomepageGood <- T.readFile "test_data/quoted_homepage_good.nix"
-      let options = Utils.Options False "" False False
+      let options = Utils.Options False False "" False False
       let updateEnv = Utils.UpdateEnv "inadyn" "2.5" "2.6" Nothing options
       -- TODO test correct file is being read
       let rwArgs = Rewrite.Args updateEnv "inadyn" undefined undefined


### PR DESCRIPTION
* instead of --dry-run use --pr to indicate a PR is wanted
* instead of additional updates, have update take the update as an
argument
* print out stdout instead of log file in the case of non-batch
updates
* print PR message to log even in the case of no PR


```

$ cabal v2-exec nixpkgs-update -- --help
nixpkgs-update

Usage: nixpkgs-update COMMAND
  Update packages in the Nixpkgs repository

Available options:
  -h,--help                Show this help text

Available commands:
  update-list              Update a list of packages
  update                   Update one package
  delete-done              Deletes branches from PRs that were merged or closed
  version                  Displays version information for nixpkgs-update and
                           dependencies
  update-vulnerability-db  Updates the vulnerability database
  check-vulnerable         checks if something is vulnerable
  check-all-vulnerable     checks all packages to update for vulnerabilities
  source-github            looks for updates on GitHub
  fetch-repology           fetches update from Repology and prints them to
                           stdout

$ cabal v2-exec nixpkgs-update -- update --help
Usage: nixpkgs-update update [--pr] [--cachix] [--outpaths] UPDATE_INFO
  Update one package

Available options:
  --pr                     Make a pull request using Hub.
  --cachix                 Push changes to Cachix
  --outpaths               Calculate outpaths to determine the branch to target
  UPDATE_INFO              update string of the form: 'pkg oldVer newVer
                           update-page' example: 'tflint 0.15.0 0.15.1
                           repology.org'
  -h,--help                Show this help text

$ cabal v2-exec nixpkgs-update -- update-list --help
Usage: nixpkgs-update update-list [--pr] [--cachix] [--outpaths]
  Update a list of packages

Available options:
  --pr                     Make a pull request using Hub.
  --cachix                 Push changes to Cachix
  --outpaths               Calculate outpaths to determine the branch to target
  -h,--help                Show this help text

```