### PR TITLE
Trim newlines in GitHub PR titles

### DIFF
--- a/nixpkgs-update.cabal
+++ b/nixpkgs-update.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0401b3234ff350b39169d38415559f3fe383a70cd04480c173c8219d5177c8ca
+-- hash: 07126c7eb0b21ed69827f9646252afa68266648544e4d54c4edf22d074c5bb19
 
 name:           nixpkgs-update
 version:        0.2.0
@@ -153,6 +153,7 @@ test-suite spec
       DoctestSpec
       RewriteSpec
       UpdateSpec
+      UtilsSpec
       Paths_nixpkgs_update
   hs-source-dirs:
       test

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -127,7 +127,7 @@ prTitle :: UpdateEnv -> Text -> Text
 prTitle updateEnv attrPath =
   let oV = oldVersion updateEnv
       nV = newVersion updateEnv
-   in [interpolate| $attrPath: $oV -> $nV |]
+   in T.strip [interpolate| $attrPath: $oV -> $nV |]
 
 regDirMode :: FileMode
 regDirMode =

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module UtilsSpec where
+
+import Test.Hspec
+import qualified Utils
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "PR title" do
+    -- This breaks IRC when it tries to link to newly opened pull requests
+    it "should not include a trailing newline" do
+      let options = Utils.Options False False "" False False False False
+      let updateEnv = Utils.UpdateEnv "foobar" "1.0" "1.1" (Just "https://update-site.com") options
+      let title = Utils.prTitle updateEnv "python37Packages.foobar"
+      title `shouldBe` "python37Packages.foobar: 1.0 -> 1.1"


### PR DESCRIPTION
The `interpolate` cmd by default is putting a trailing newline on this, as the
test case shows, so add an explicit `strip` to it.

Fixes #189

CC @ryantm @cole-h @samueldr