### PR TITLE
Cleanup whitespace in PR comment function

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -391,16 +391,16 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
       rewriteMsgsLine = foldl (\ms m -> ms <> T.pack "\n- " <> m) "\n###### Updates performed" rewriteMsgs
       maintainersCc =
         if not (T.null maintainers)
-          then "\n\ncc " <> maintainers <> " for testing."
+          then "cc " <> maintainers <> " for testing."
           else ""
       releaseUrlMessage =
         if releaseUrl == T.empty
           then ""
-          else "\n- [Release on GitHub](" <> releaseUrl <> ")"
+          else "- [Release on GitHub](" <> releaseUrl <> ")"
       compareUrlMessage =
         if compareUrl == T.empty
           then ""
-          else "\n- [Compare changes on GitHub](" <> compareUrl <> ")\n\n"
+          else "- [Compare changes on GitHub](" <> compareUrl <> ")"
       nixpkgsReviewSection =
         if nixpkgsReviewMsg == T.empty
           then "NixPkgs review skipped"
@@ -431,6 +431,7 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
        ###### To inspect upstream changes
 
        $releaseUrlMessage
+
        $compareUrlMessage
 
        ###### Impact

--- a/test_data/expected_pr_description_1.md
+++ b/test_data/expected_pr_description_1.md
@@ -14,11 +14,9 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ###### To inspect upstream changes
 
-
 - [Release on GitHub](https://github.com/foobar/releases)
 
 - [Compare changes on GitHub](https://github.com/foobar/compare)
-
 
 ###### Impact
 
@@ -85,7 +83,5 @@ nixpkgs-review comment body
 ---
 
 ###### Maintainer pings
-
-
 
 cc @maintainer1 for testing.

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -14,11 +14,9 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ###### To inspect upstream changes
 
-
 - [Release on GitHub](https://github.com/foobar/releases)
 
 - [Compare changes on GitHub](https://github.com/foobar/compare)
-
 
 ###### Impact
 
@@ -78,7 +76,5 @@ NixPkgs review skipped
 ---
 
 ###### Maintainer pings
-
-
 
 cc @maintainer1 for testing.


### PR DESCRIPTION
Since we have an interpolated string, let's try to keep the newlines inside the
interpolation region, rather than attached to the variables -- particularly when
it's multiple newlines. This makes it easier to read/visualize what the PR
description will look like.

Updated and trimmed some excessive whitespace. This doesn't cause a rendering
diff on the UI, but makes the raw output cleaner.