### PR TITLE
Pull GitHub Username from hub cfg instead of hard-coding r-ryantm

### DIFF
--- a/src/DeleteMerged.hs
+++ b/src/DeleteMerged.hs
@@ -8,15 +8,16 @@ import OurPrelude
 
 import qualified Data.Text.IO as T
 import qualified GH
+import GitHub.Data (Name, Owner)
 import qualified Git
 
-deleteDone :: Text -> IO ()
-deleteDone githubToken = do
+deleteDone :: Text -> Name Owner -> IO ()
+deleteDone githubToken ghUser = do
   result <-
     runExceptT $ do
       Git.fetch
       Git.cleanAndResetTo "master"
-      refs <- ExceptT $ GH.closedAutoUpdateRefs (GH.authFromToken githubToken)
+      refs <- ExceptT $ GH.closedAutoUpdateRefs (GH.authFromToken githubToken) ghUser
       let branches = fmap (\r -> ("auto-update/" <> r)) refs
       liftIO $ Git.deleteBranchesEverywhere branches
   case result of

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -84,6 +84,7 @@ getLog o = do
 notifyOptions :: (Text -> IO ()) -> Options -> IO ()
 notifyOptions log o = do
   let repr f = if f o then "YES" else " NO"
+  let ghUser = GH.untagName . githubUser $ o
   let pr = repr doPR
   let cachix = repr pushToCachix
   let outpaths = repr calculateOutpaths
@@ -92,6 +93,7 @@ notifyOptions log o = do
   log $ [interpolate|
     Configured Nixpkgs-Update Options:
     ----------------------------------
+    GitHub User:                   $ghUser
     Send pull request on success:  $pr
     Push to cachix:                $cachix
     Calculate Outpaths:            $outpaths
@@ -337,8 +339,7 @@ publishPackage log updateEnv oldSrcUrl newSrcUrl attrPath result opDiff rewriteM
   liftIO $ log prMsg
   if (doPR . options $ updateEnv)
     then do
-      -- FIXME: #192 This needs to be detected dynamically. Use the hub token or GH library?
-      let ghUser = "r-ryantm"
+      let ghUser = GH.untagName . githubUser . options $ updateEnv
       pullRequestUrl <- GH.pr updateEnv (prTitle updateEnv attrPath) prMsg (ghUser <> ":" <> (branchName updateEnv)) prBase
       liftIO $ log pullRequestUrl
     else liftIO $ T.putStrLn prMsg

--- a/test/RewriteSpec.hs
+++ b/test/RewriteSpec.hs
@@ -23,7 +23,7 @@ spec = do
     it "quotes an unquoted meta.homepage URL" do
       nixQuotedHomepageBad <- T.readFile "test_data/quoted_homepage_bad.nix"
       nixQuotedHomepageGood <- T.readFile "test_data/quoted_homepage_good.nix"
-      let options = Utils.Options False False "" False False False False
+      let options = Utils.Options False False "" "" False False False False
       let updateEnv = Utils.UpdateEnv "inadyn" "2.5" "2.6" Nothing options
       -- TODO test correct file is being read
       let rwArgs = Rewrite.Args updateEnv "inadyn" undefined undefined

--- a/test/UpdateSpec.hs
+++ b/test/UpdateSpec.hs
@@ -18,7 +18,7 @@ spec :: Spec
 spec = do
   describe "PR message" do
     -- Common mock options
-    let options = Utils.Options False False "" False False False False
+    let options = Utils.Options False False "" "" False False False False
     let updateEnv = Utils.UpdateEnv "foobar" "1.0" "1.1" (Just "https://update-site.com") options
     let isBroken = False
     let metaDescription = "\"Foobar package description\""

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -13,7 +13,7 @@ spec = do
   describe "PR title" do
     -- This breaks IRC when it tries to link to newly opened pull requests
     it "should not include a trailing newline" do
-      let options = Utils.Options False False "" False False False False
+      let options = Utils.Options False False "" "" False False False False
       let updateEnv = Utils.UpdateEnv "foobar" "1.0" "1.1" (Just "https://update-site.com") options
       let title = Utils.prTitle updateEnv "python37Packages.foobar"
       title `shouldBe` "python37Packages.foobar: 1.0 -> 1.1"


### PR DESCRIPTION
Resolves #192

Also avoids the unqualified import on `GitHub` in GH.hs, since this lib's types
are already complex/confusing enough without the ambiguity!