### PR TITLE
Blacklist ocamlPackages

### DIFF
--- a/src/Blacklist.hs
+++ b/src/Blacklist.hs
@@ -60,6 +60,9 @@ attrPathList =
   , prefix
       "deepin"
       "deepin packages are upgraded in lockstep https://github.com/NixOS/nixpkgs/pull/52327#issuecomment-447684194"
+  , prefix
+      "ocaml"
+      "missing dependencies don't always result in build failures in ocamlPackages so the bot will PR incorrect updates"
   ]
 
 nameList :: Blacklist


### PR DESCRIPTION
The bot will often PR package updates which are missing added dependencies. This is caused by the heavy propagation in `ocamlPackages` which causes missing dependencies to not always result in a build failure because it is likely to be propagated from somewhere else (at least this is how I understand it).

An example would be <https://github.com/NixOS/nixpkgs/pull/90630>.

Any thoughts on this?

cc @vbgl