### PR TITLE
use flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,33 +1,8 @@
-{ returnShellEnv ? false } :
-
+{returnShellEnv ? false  } :
 let
   sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {config = { allowBroken = true; }; };
-
-  gitignore = import sources.gitignore { inherit (pkgs) lib; };
-  inherit (gitignore) gitignoreSource;
-
-  compiler = pkgs.haskell.packages.ghc883;
-  inherit (pkgs.haskell.lib) dontCheck doJailbreak overrideCabal;
-
-  pkg = compiler.developPackage {
-    name = "nixpkgs-update";
-    root = gitignoreSource ./.;
-    overrides = self: super: { };
-    source-overrides = { };
-    inherit returnShellEnv;
-  };
-
-in pkg.overrideAttrs (attrs: {
-  propagatedBuildInputs = with pkgs; [
-    nix
-    git
-    getent
-    gitAndTools.hub
-    jq
-    tree
-    gist
-    (import sources.nixpkgs-review { inherit pkgs; })
-    cabal-install # just for develpoment
-  ];
-})
+  flake-compat = import sources.flake-compat { src = ./.; };
+in
+if returnShellEnv
+then flake-compat.shellNix.default
+else flake-compat.defaultNix.default

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
-    "gitignore": {
+    "flake-compat": {
         "branch": "master",
-        "description": "Nix function for filtering local git sources",
-        "homepage": "",
-        "owner": "hercules-ci",
-        "repo": "gitignore",
-        "rev": "2ced4519f865341adcb143c5d668f955a2cb997f",
-        "sha256": "0fc5bgv9syfcblp23y05kkfnpgh3gssz6vn24frs8dzw39algk2z",
+        "description": null,
+        "homepage": null,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "c75e76f80c57784a6734356315b306140646ee84",
+        "sha256": "071aal00zp2m9knnhddgr2wqzlx6i6qa1263lv1y7bdn2w20h10h",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore/archive/2ced4519f865341adcb143c5d668f955a2cb997f.tar.gz",
+        "url": "https://github.com/edolstra/flake-compat/archive/c75e76f80c57784a6734356315b306140646ee84.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -21,30 +21,6 @@
         "sha256": "0jlmrx633jvqrqlyhlzpvdrnim128gc81q5psz2lpp2af8p8q9qs",
         "type": "tarball",
         "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "master",
-        "description": "Nix Packages collection",
-        "homepage": null,
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "78bfdbb291fd20df0f0f65061ee3081610b0a48f",
-        "sha256": "0qy72dm799vrmcmb72zcxkj2rrcgqgsj0z58f9gl069p9aag2z3a",
-        "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/78bfdbb291fd20df0f0f65061ee3081610b0a48f.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs-review": {
-        "branch": "master",
-        "description": "Review pull-requests on https://github.com/NixOS/nixpkgs",
-        "homepage": "",
-        "owner": "mic92",
-        "repo": "nixpkgs-review",
-        "rev": "370e90a8d20640cc8924dacb4f55a86dadcec57f",
-        "sha256": "026lmwbvqdp7a3nkd08rd0nfyb9yiic36w6s7mh2rpp0ihp7qsd6",
-        "type": "tarball",
-        "url": "https://github.com/mic92/nixpkgs-review/archive/370e90a8d20640cc8924dacb4f55a86dadcec57f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
* removes redundancy between default.nix and flake.nix
* removes redundancy in niv lock vs flake.lock