### PR TITLE
bake dependency references into executable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,18 +29,15 @@
           root = self;
           overrides = self: super: { };
           source-overrides = { };
-        }).overrideAttrs (attrs: {
-          propagatedBuildInputs = with pkgs; [
-            nix
-            git
-            getent
-            gitAndTools.hub
-            jq
-            tree
-            gist
-            (import nixpkgs-review { inherit pkgs; })
-            cabal-install # just for develpoment
-          ];
+        }).overrideAttrs (attrs: with pkgs; {
+          # TODO: lock down coreutils paths too
+          NIX = nix;
+          GIT = git;
+          HUB = gitAndTools.hub;
+          JQ = jq;
+          TREE = tree;
+          GIST = gist;
+          NIXPKGSREVIEW = (import nixpkgs-review { inherit pkgs; });
         });
     in
     {

--- a/nixpkgs-update.cabal
+++ b/nixpkgs-update.cabal
@@ -4,7 +4,7 @@ cabal-version: 2.2
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 423912d97dc4b89c2c6324797efb0befbf8ddf7701f87d49c4da3e9ee426419f
+-- hash: 2434848b7fd81488fc4e9c5c41882ad1c0b11f6922f982686b155bb6713dd2fc
 
 name:           nixpkgs-update
 version:        0.2.0
@@ -87,6 +87,7 @@ library
     , template-haskell
     , temporary
     , text
+    , th-env
     , time
     , transformers
     , typed-process
@@ -139,6 +140,7 @@ executable nixpkgs-update
     , template-haskell
     , temporary
     , text
+    , th-env
     , time
     , transformers
     , typed-process
@@ -199,6 +201,7 @@ test-suite spec
     , template-haskell
     , temporary
     , text
+    , th-env
     , time
     , transformers
     , typed-process

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ dependencies:
   - template-haskell
   - temporary
   - text
+  - th-env
   - time
   - transformers
   - typed-process


### PR DESCRIPTION
instead of relying on, for example, hub being on the PATH, use a
specific version from the build environment.

closes #217