### PR TITLE
switch the caches to nix-community.cachix.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ why your pet package is not receiving updates.
 ## Cachix
 
 By uploading the build outputs to
-[Cachix](https://r-ryantm.cachix.org/), nixpkgs-update allows you to
+[Cachix](https://nix-community.cachix.org/), nixpkgs-update allows you to
 test a package with one command.
 
 

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -7,7 +7,6 @@ module Nix
     assertOldVersionOn,
     binPath,
     build,
-    cachix,
     getAttr,
     getChangelog,
     getDerivationFile,
@@ -275,16 +274,6 @@ build attrPath =
         ourReadProcessInterleaved_ (log attrPath)
           & fmap (T.lines >>> reverse >>> take 30 >>> reverse >>> T.unlines)
       throwE ("nix build failed.\n" <> buildLog <> " ")
-
-cachix :: MonadIO m => Text -> ExceptT Text m ()
-cachix resultPath =
-  ( setStdin
-      (byteStringInput (TL.encodeUtf8 (TL.fromStrict resultPath)))
-      (shell "cachix push r-ryantm")
-      & runProcess_
-      & tryIOTextET
-  )
-    <|> throwE "pushing to cachix failed"
 
 numberOfFetchers :: Text -> Int
 numberOfFetchers derivationContents =

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -636,16 +636,14 @@ doCachix :: MonadIO m => (Text -> m ()) -> UpdateEnv -> Text -> ExceptT Text m T
 doCachix log updateEnv resultPath =
   if pushToCachix (options updateEnv)
     then do
-      lift $ log ("cachix " <> (T.pack . show) resultPath)
-      Nix.cachix resultPath
       return
         [interpolate|
        Either **download from Cachix**:
        ```
        nix-store -r $resultPath \
-         --option binary-caches 'https://cache.nixos.org/ https://r-ryantm.cachix.org/' \
+         --option binary-caches 'https://cache.nixos.org/ https://nix-community.cachix.org/' \
          --option trusted-public-keys '
-         r-ryantm.cachix.org-1:gkUbLkouDAyvBdpBX0JOdIiD2/DP1ldF3Z3Y6Gqcc4c=
+         nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
          cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
          '
        ```


### PR DESCRIPTION
Share the caching infrastructure with the nix-community project.

The cache is automatically done in a post-build hook so the bot doesn't
need to this.

The deployment of this would be coordinated with https://github.com/nix-community/infra/pull/35