### PR TITLE
docs: Clarify requirements for GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,14 @@ nixpkgs-update supports interactive, single package updates via the
 
 # Update tutorial
 
-1. Setup [hub](https://github.com/github/hub) and give it your GitHub
-   credentials, so it saves an oauth token. This allows nixpkgs-update
-   to query the GitHub API.
+1. Setup [`hub`](https://github.com/github/hub) and give it your
+   GitHub credentials.  Alternatively, if you prefer not to install
+   and configure `hub`, you can manually create a GitHub token with
+   `repo` and `gist` scopes.  Provide it to `nixpkgs-update` by
+   exporting it as the `GITHUB_TOKEN` environment variable
+   (`nixpkgs-update` _only_ tries to use `hub` to check out the
+   `nixpkgs` repo into your XDG cache directory, if you run
+   `nixpkgs-update` outside of a `nixpkgs` checkout directory).
 2. Go to your local checkout of nixpkgs, and **make sure the working
    directory is clean**. Be on a branch you are okay committing to.
 3. Run it like: `nixpkgs-update update "postman 7.20.0 7.21.2"`


### PR DESCRIPTION
For people that would rather not install `hub`, we make a note of the required API token scopes and document how to provide it to nixpkgs-update.

As described in https://github.com/ryantm/nixpkgs-update/issues/137#issuecomment-722802963