### PR TITLE
Fix running binary checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,13 +18,14 @@
         };
 
         drvAttrs = attrs: with pkgs; {
-          # TODO: lock down coreutils paths too
           NIX = nix;
           GIT = git;
           HUB = gitAndTools.hub;
           JQ = jq;
           TREE = tree;
           GIST = gist;
+          # TODO: are there more coreutils paths that need locking down?
+          TIMEOUT = coreutils;
           NIXPKGSREVIEW = (import nixpkgs-review { inherit pkgs; });
         };
 


### PR DESCRIPTION
* Make sure to use the absolute path to the binary when passing it to `doesFileExist`.
* Don't include the path in the temporary directory, as it contains characters that are invalid there.
* Use the full path to the coreutils 'timeout' utility

Refs #242