### PR TITLE
Skiplist: add Pantheon

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -132,7 +132,8 @@ contentList =
     infixOf "buildPerlPackage" "Derivation contains buildPerlPackage",
     -- Specific skips for classes of packages
     infixOf "goDeps" "Derivation contains goDeps attribute",
-    infixOf "https://downloads.haskell.org/ghc/" "GHC packages are versioned per file"
+    infixOf "https://downloads.haskell.org/ghc/" "GHC packages are versioned per file",
+    infixOf "pantheon" "Do not update Pantheon during a release cycle"
   ]
 
 checkResultList :: Skiplist


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/135170#issuecomment-903208319

We are upgrading Pantheon to version 6 in https://github.com/NixOS/nixpkgs/pull/130380 and due to usability issues we are not able to merged that in a short period. At the same time the bot is [opening some duplicate PRs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+is%3Aopen+label%3A%222.status%3A+duplicate%22+label%3A%226.topic%3A+pantheon%22) and some of the upgraded packages will not work in Pantheon 5.1. Will be great if we can temporarily skip this until https://github.com/NixOS/nixpkgs/pull/130380 is merged as I know [more Pantheon updates](https://twitter.com/elementary/status/1427417033440997381) is coming.

@ryantm 
