### PR TITLE
flake.nix: Add nixpkgs-update cachix as an extra substituter to the

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,9 @@
   inputs.nixpkgs = { type = "github"; owner = "nixos"; repo = "nixpkgs"; };
   inputs.mmdoc.url = "github:ryantm/mmdoc";
 
+  nixConfig.extra-substituters = [ "https://nixpkgs-update.cachix.org" ];
+  nixConfig.extra-trusted-public-keys = [ "nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=" ];
+
   outputs = { self, flake-compat, nixpkgs, nixpkgs-review, mmdoc } @ args:
     {
       packages."x86_64-linux" = import ./pkgs/default.nix (args // { system = "x86_64-linux"; });
@@ -15,6 +18,5 @@
       packages."x86_64-darwin" = import ./pkgs/default.nix (args // { system = "x86_64-darwin"; });
       defaultPackage."x86_64-darwin" = self.packages."x86_64-darwin".nixpkgs-update;
       devShell."x86_64-darwin" = self.packages."x86_64-darwin".devShell;
-
     };
 }


### PR DESCRIPTION
@ryantm 