### PR TITLE
Add workarounds for Firefox binary packages

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -8,6 +8,8 @@ module Skiplist
     attrPath,
     checkResult,
     python,
+    skipOutpathCalc,
+    overrideDerivationFile,
   )
 where
 
@@ -36,6 +38,12 @@ content = skiplister contentList
 
 checkResult :: TextSkiplister m
 checkResult = skiplister checkResultList
+
+skipOutpathCalc :: TextSkiplister m
+skipOutpathCalc = skiplister skipOutpathCalcList
+
+overrideDerivationFile :: TextSkiplister m
+overrideDerivationFile = skiplister overrideDerivationFileList
 
 attrPathList :: Skiplist
 attrPathList =
@@ -159,6 +167,20 @@ checkResultList =
     binariesStickAround "fail2ban",
     binariesStickAround "zed",
     binariesStickAround "haveged"
+  ]
+
+skipOutpathCalcList :: Skiplist
+skipOutpathCalcList =
+  [ eq "firefox-beta-bin-unwrapped" "master"
+  , eq "firefox-devedition-bin-unwrapped" "master"
+  -- "firefox-release-bin-unwrapped" is unneeded here because firefox-bin is a dependency of other packages that Hydra doesn't ignore.
+  ]
+
+overrideDerivationFileList :: Skiplist
+overrideDerivationFileList =
+  [ eq "firefox-beta-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix"
+  , eq "firefox-devedition-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix"
+  , eq "firefox-release-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/release_sources.nix"
   ]
 
 binariesStickAround :: Text -> (Text -> Bool, Text)


### PR DESCRIPTION
The binary Firefox packages don't get cached in Hydra and don't have
their version numbers appear as strings in the file that `nix edit`
identifies. To solve these problems, we add two escape hatches: a list
of packages for which outpath diffing is skipped, and a list of
overrides to use instead of `nix edit` for identifying the correct Nix
file to scan for version numbers.

[Discourse thread](https://discourse.nixos.org/t/automating-version-bumps-of-non-release-firefox-channels/17810)