### PR TITLE
gitremote is not a command

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -171,7 +171,7 @@ setupNixpkgs githubt = do
         ]
       & runProcess_
     setCurrentDirectory fp
-    shell (bin <> "remote add upstream https://github.com/NixOS/nixpkgs")
+    shell (bin <> " remote add upstream https://github.com/NixOS/nixpkgs")
       & runProcess_
   inNixpkgs <- inNixpkgsRepo
   unless inNixpkgs do


### PR DESCRIPTION
Fixes:
```
/bin/sh: line 1: /nix/store/ix1391mfshicnygbzxpdwqsi4hvzjy7s-git-2.32.0/bin/gitremote: No such file or directory
nixpkgs-update: Received ExitFailure 127 when running
Shell command: /nix/store/ix1391mfshicnygbzxpdwqsi4hvzjy7s-git-2.32.0/bin/gitremote add upstream https://github.com/NixOS/nixpkgs
```