### PR TITLE
docs: use extra-trusted-public-keys instead

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -10,7 +10,7 @@ Run without installing on stable Nix:
 ```ShellSession
 $ nix run \
   --option extra-substituters 'https://nixpkgs-update.cachix.org/' \
-  --option trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
+  --option extra-trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
   -f https://github.com/ryantm/nixpkgs-update/archive/main.tar.gz \
   -c nixpkgs-update --help
 ```
@@ -20,7 +20,7 @@ Run without installing on unstable Nix with nix command enabled:
 ```ShellSession
 $ nix shell \
   --option extra-substituters 'https://nixpkgs-update.cachix.org/' \
-  --option trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
+  --option extra-trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
   -f https://github.com/ryantm/nixpkgs-update/archive/main.tar.gz \
   -c nixpkgs-update --help
 ```
@@ -30,7 +30,7 @@ Run without installing on unstable Nix with nix flakes enabled:
 ```ShellSession
 $ nix run \
   --option extra-substituters 'https://nixpkgs-update.cachix.org/' \
-  --option trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
+  --option extra-trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
   github:ryantm/nixpkgs-update -- --help
 ```
 
@@ -39,7 +39,7 @@ Install into your Nix profile:
 ```ShellSession
 $ nix-env \
   --option extra-substituters 'https://nixpkgs-update.cachix.org/' \
-  --option trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
+  --option extra-trusted-public-keys 'nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=' \
   -if https://github.com/ryantm/nixpkgs-update/archive/main.tar.gz
 ```
 


### PR DESCRIPTION
This commit is a simple docs change for running with nix run / nix
shell.

Without using `extra-trusted-public-keys`, we no longer trust
cache.nixos.org's key. This makes it an append so we can still use the
Big Cache.