### PR TITLE
Reuse an existing auto-update PR

### DIFF
--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -24,6 +24,7 @@ module Utils
     runLog,
     srcOrMain,
     stripQuotes,
+    titleTargetsSameVersion,
     tRead,
     whenBatch,
     regDirMode,
@@ -135,6 +136,11 @@ prTitle updateEnv attrPath =
   let oV = oldVersion updateEnv
       nV = newVersion updateEnv
    in T.strip [interpolate| $attrPath: $oV -> $nV |]
+
+titleTargetsSameVersion :: UpdateEnv -> Text -> Bool
+titleTargetsSameVersion updateEnv = T.isSuffixOf [interpolate| -> $nV |]
+  where
+    nV = newVersion updateEnv
 
 regDirMode :: FileMode
 regDirMode =


### PR DESCRIPTION
During a batch update, instead of aborting if an auto update branch for
a package exists, do the following:

  * Abort if the last commit on the branch updates the package to the
    same version.

  * Abort if, for some reason, there is more than one open PR
    corresponding to that branch.

  * Fall back to creating a PR if there are zero open PRs corresponding
    to that branch (this could happen if a human closes the PR during
    the updater run).

  * Otherwise, force-push the new update to that branch, update the
    title of the PR to reflect the new version numbers, and post a
    comment to the PR with the new PR message.

Closes #64.