### PR TITLE
Fix bug when checking auto-update branch version

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -368,7 +368,7 @@ updateAttrPath log mergeBase updateEnv@UpdateEnv {..} attrPath = do
         when hasUpdateScript do
           tryAssert
             "An auto update branch exists targeting the same version"
-            (not $ any (U.titleTargetsSameVersion updateEnv) existingCommitMsg)
+            (not $ any (U.titleTargetsSameVersion updateEnv') existingCommitMsg)
 
           -- Note that this check looks for PRs with the same old and new
           -- version numbers, so it won't stop us from updating an existing PR


### PR DESCRIPTION
When updating `python310Packages.flask_login`, [this run](https://r.ryantm.com/log/python310Packages.flask_login/2022-08-16.log) was triggered by Repology, so the original `updateEnv` contained the appropriate new version number. In [other runs](https://r.ryantm.com/log/python310Packages.flask_login/2022-08-17.log), the original `updateEnv` didn't contain the appropriate new version number, so comparing the version in `updateEnv` (as opposed to `updateEnv'`) made nixpkgs-update think that the branch version didn't match the new version even though it did.

This PR also adds logging to make this sort of mistake more legible in the future.