### PR TITLE
Remove unused functions

### DIFF
--- a/src/Check.hs
+++ b/src/Check.hs
@@ -34,12 +34,6 @@ procTree = proc treeBin
 gistBin :: String
 gistBin = fromJust ($$(envQ "GIST") :: Maybe String) <> "/bin/gist"
 
-procGist :: [String] -> ProcessConfig () () ()
-procGist = proc gistBin
-
-timeoutBin :: String
-timeoutBin = fromJust ($$(envQ "TIMEOUT") :: Maybe String) <> "/bin/timeout"
-
 data BinaryCheck = BinaryCheck
   { filePath :: FilePath,
     zeroExitCode :: Bool,
@@ -95,16 +89,6 @@ checkTestsBuildReport False =
   "- Warning: a test defined in `passthru.tests` did not pass"
 checkTestsBuildReport True =
   "- The tests defined in `passthru.tests`, if any, passed"
-
-ourLockedDownReadProcessInterleaved ::
-  MonadIO m =>
-  ProcessConfig stdin stdoutIgnored stderrIgnored ->
-  FilePath ->
-  ExceptT Text m (ExitCode, Text)
-ourLockedDownReadProcessInterleaved processConfig tempDir =
-  processConfig & setWorkingDir tempDir
-    & setEnv [("EDITOR", "echo"), ("HOME", "/we-dont-write-to-home")]
-    & ourReadProcessInterleaved
 
 foundVersionInOutputs :: Text -> String -> IO (Maybe Text)
 foundVersionInOutputs expectedVersion resultPath =

--- a/src/Git.hs
+++ b/src/Git.hs
@@ -5,7 +5,6 @@ module Git
   ( findAutoUpdateBranchMessage,
     mergeBase,
     cleanAndResetTo,
-    cleanup,
     commit,
     deleteBranchesEverywhere,
     delete1,
@@ -101,13 +100,6 @@ cleanAndResetTo branch =
 show :: MonadIO m => Text -> Text -> ExceptT Text m Text
 show branch file =
   readProcessInterleavedNoIndexIssue_ $ silently $ procGit ["show", T.unpack ("remotes/upstream/" <> branch <> ":" <> file)]
-
-cleanup :: MonadIO m => Text -> ExceptT Text m ()
-cleanup bName = do
-  liftIO $ T.putStrLn ("Cleaning up " <> bName)
-  cleanAndResetTo "master"
-  runProcessNoIndexIssue_ (delete1' bName)
-    <|> liftIO (T.putStrLn ("Couldn't delete " <> bName))
 
 diff :: MonadIO m => Text -> ExceptT Text m Text
 diff branch = readProcessInterleavedNoIndexIssue_ $ procGit ["diff", T.unpack branch]

--- a/src/OurPrelude.hs
+++ b/src/OurPrelude.hs
@@ -28,7 +28,6 @@ module OurPrelude
     ourReadProcessInterleaved_,
     ourReadProcessInterleavedBS_,
     ourReadProcessInterleaved,
-    ourReadProcessInterleaved_Sem,
     ourReadProcessInterleavedSem,
     silently,
     bytestringToText,
@@ -100,13 +99,6 @@ ourReadProcessInterleaved_ ::
   ExceptT Text m Text
 ourReadProcessInterleaved_ =
   readProcessInterleaved_ >>> tryIOTextET >>> fmapRT bytestringToText
-
-ourReadProcessInterleaved_Sem ::
-  Members '[P.Process] r =>
-  ProcessConfig stdin stdoutIgnored stderrIgnored ->
-  Sem r Text
-ourReadProcessInterleaved_Sem =
-  P.readInterleaved_ >>> fmap bytestringToText
 
 ourReadProcessInterleaved ::
   MonadIO m =>

--- a/src/Repology.hs
+++ b/src/Repology.hs
@@ -23,13 +23,13 @@ baseUrl = BaseUrl Https "repology.org" 443 "/api/v1"
 
 type Metapackage = Vector Package
 
-compareMetapackage :: Metapackage -> Metapackage -> Ordering
-compareMetapackage ps1 ps2 = compareMetapackage' (ps1 V.!? 0) (ps2 V.!? 0)
-  where
-    compareMetapackage' (Just p1) (Just p2) = compare (name p1) (name p2)
-    compareMetapackage' Nothing (Just _) = LT
-    compareMetapackage' (Just _) Nothing = GT
-    compareMetapackage' _ _ = EQ
+-- compareMetapackage :: Metapackage -> Metapackage -> Ordering
+-- compareMetapackage ps1 ps2 = compareMetapackage' (ps1 V.!? 0) (ps2 V.!? 0)
+--   where
+--     compareMetapackage' (Just p1) (Just p2) = compare (name p1) (name p2)
+--     compareMetapackage' Nothing (Just _) = LT
+--     compareMetapackage' (Just _) Nothing = GT
+--     compareMetapackage' _ _ = EQ
 
 type Metapackages = HashMap Text Metapackage
 
@@ -87,8 +87,8 @@ metapackage :<|> metapackages :<|> metapackages' = client api
 lastMetapackageName :: Metapackages -> Maybe Text
 lastMetapackageName = keys >>> sort >>> Prelude.reverse >>> headMay
 
-sortedMetapackages :: Metapackages -> Vector Metapackage
-sortedMetapackages = elems >>> sortBy compareMetapackage >>> V.fromList
+-- sortedMetapackages :: Metapackages -> Vector Metapackage
+-- sortedMetapackages = elems >>> sortBy compareMetapackage >>> V.fromList
 
 nixRepo :: Text
 nixRepo = "nix_unstable"

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -18,14 +18,12 @@ module Utils
     logDir,
     nixBuildOptions,
     nixCommonOptions,
-    overwriteErrorT,
     parseUpdates,
     prTitle,
     runLog,
     srcOrMain,
     stripQuotes,
     titleTargetsSameVersion,
-    tRead,
     whenBatch,
     regDirMode,
     outpathCacheDir,
@@ -225,9 +223,6 @@ logDir = do
     Right dir -> return dir
     Left e -> error $ T.unpack e
 
-overwriteErrorT :: MonadIO m => Text -> ExceptT Text m a -> ExceptT Text m a
-overwriteErrorT t = fmapLT (const t)
-
 branchPrefix :: Text
 branchPrefix = "auto-update/"
 
@@ -241,9 +236,6 @@ parseUpdates = map (toTriple . T.words) . T.lines
     toTriple [package, oldVer, newVer] = Right (package, oldVer, newVer, Nothing)
     toTriple [package, oldVer, newVer, url] = Right (package, oldVer, newVer, Just url)
     toTriple line = Left $ "Unable to parse update: " <> T.unwords line
-
-tRead :: Read a => Text -> a
-tRead = read . T.unpack
 
 srcOrMain :: MonadIO m => (Text -> ExceptT Text m a) -> Text -> ExceptT Text m a
 srcOrMain et attrPath = et (attrPath <> ".src") <|> et attrPath


### PR DESCRIPTION
None of the removed functions are used anywhere in this project, including tests. The functions that I commented out rather than deleting entirely were used in other commented-out functions—not sure if that's what you'd want.

There are a few more unused functions in the `Time` module but I left them alone because it looked like they're intended to be used as part of some sort of testing that hasn't been written yet.