### PR TITLE
Avoid updating spire three times

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -77,6 +77,9 @@ attrPathList =
     infixOf
       "tornado"
       "python updatescript updates pinned versions",
+    prefix
+      "spire-"
+      "spire-server and spire-agent are different outputs for spire package",
     eq "imagemagick_light" "same file and version as imagemagick",
     eq "imagemagickBig" "same file and version as imagemagick"
   ]


### PR DESCRIPTION
I split spire into 3 different outputs https://github.com/NixOS/nixpkgs/blob/4ffd6bd6f6b6bfdf2c7810bbad09ac46582613b3/pkgs/tools/security/spire/default.nix#L7, one agent, one server, and the default contains both.

The reasoning was that most scenarios need to use one or the other but not both, so it didn't make sense to always have both in every scenario. This is great for smaller runtime closures, but a bit odd for nixpkgs-update as there's three attrs which point to the same package.

Example updates:
- https://github.com/NixOS/nixpkgs/pull/190177
- https://github.com/NixOS/nixpkgs/pull/190178
- https://github.com/NixOS/nixpkgs/pull/190179