### PR TITLE
If updateScript changes any single file, use that

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -9,6 +9,7 @@ module Git
     deleteBranchesEverywhere,
     delete1,
     diff,
+    diffFileNames,
     fetch,
     fetchIfStale,
     headRev,
@@ -103,6 +104,10 @@ show branch file =
 
 diff :: MonadIO m => Text -> ExceptT Text m Text
 diff branch = readProcessInterleavedNoIndexIssue_ $ procGit ["diff", T.unpack branch]
+
+diffFileNames :: MonadIO m => Text -> ExceptT Text m [Text]
+diffFileNames branch = readProcessInterleavedNoIndexIssue_ (procGit ["diff", T.unpack branch, "--name-only"])
+  & fmapRT T.lines
 
 staleFetchHead :: MonadIO m => m Bool
 staleFetchHead =

--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -9,7 +9,6 @@ module Skiplist
     checkResult,
     python,
     skipOutpathCalc,
-    overrideDerivationFile,
   )
 where
 
@@ -41,9 +40,6 @@ checkResult = skiplister checkResultList
 
 skipOutpathCalc :: TextSkiplister m
 skipOutpathCalc = skiplister skipOutpathCalcList
-
-overrideDerivationFile :: TextSkiplister m
-overrideDerivationFile = skiplister overrideDerivationFileList
 
 attrPathList :: Skiplist
 attrPathList =
@@ -180,13 +176,6 @@ skipOutpathCalcList =
   [ eq "firefox-beta-bin-unwrapped" "master"
   , eq "firefox-devedition-bin-unwrapped" "master"
   -- "firefox-release-bin-unwrapped" is unneeded here because firefox-bin is a dependency of other packages that Hydra doesn't ignore.
-  ]
-
-overrideDerivationFileList :: Skiplist
-overrideDerivationFileList =
-  [ eq "firefox-beta-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/beta_sources.nix"
-  , eq "firefox-devedition-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/devedition_sources.nix"
-  , eq "firefox-release-bin-unwrapped" "pkgs/applications/networking/browsers/firefox-bin/release_sources.nix"
   ]
 
 binariesStickAround :: Text -> (Text -> Bool, Text)


### PR DESCRIPTION
For checking if a version has been updated on any branch, if an updateScript was used and changed a single file, then use that file instead of the derivation file from `nix edit`.

This should be more reliable than the previous skiplist approach for idiosyncratic source files.

I've tested that this still works with the `firefox-*-bin-unwrapped` packages, which was the original motivation for the `overrideDerivationFile` skiplist. But now it should work automatically with more packages (I was looking specifically at wine, but there are probably others that will benefit).