### PR TITLE
Check for result-dev links

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -288,6 +288,7 @@ resultLink =
   T.strip
     <$> ( ourReadProcessInterleaved_ "readlink ./result"
             <|> ourReadProcessInterleaved_ "readlink ./result-bin"
+            <|> ourReadProcessInterleaved_ "readlink ./result-dev"
         )
     <|> throwE "Could not find result link. "
 


### PR DESCRIPTION
Example failing upgrade that this would fix: https://r.ryantm.com/log/raft-canonical/2022-11-16.log