### PR TITLE
Drop hub dependency

### DIFF
--- a/doc/batch-updates.md
+++ b/doc/batch-updates.md
@@ -7,7 +7,12 @@ subcommand.
 
 1. Setup [hub](https://github.com/github/hub) and give it your GitHub
    credentials, so it saves an oauth token. This allows nixpkgs-update
-   to query the GitHub API.
+   to query the GitHub API.  Alternatively, if you prefer not to install
+   and configure `hub`, you can manually create a GitHub token with
+   `repo` and `gist` scopes.  Provide it to `nixpkgs-update` by
+   exporting it as the `GITHUB_TOKEN` environment variable
+   (`nixpkgs-update` reads credentials from the files `hub` uses but
+   no longer uses `hub` itself).
 
 2. Clone this repository and build `nixpkgs-update`:
     ```bash

--- a/doc/interactive-updates.md
+++ b/doc/interactive-updates.md
@@ -10,9 +10,8 @@ nixpkgs-update supports interactive, single package updates via the
    and configure `hub`, you can manually create a GitHub token with
    `repo` and `gist` scopes.  Provide it to `nixpkgs-update` by
    exporting it as the `GITHUB_TOKEN` environment variable
-   (`nixpkgs-update` _only_ tries to use `hub` to check out the
-   `nixpkgs` repo into your XDG cache directory, if you run
-   `nixpkgs-update` outside of a `nixpkgs` checkout directory).
+   (`nixpkgs-update` reads credentials from the files `hub` uses but
+   no longer uses `hub` itself).
 2. Go to your local checkout of nixpkgs, and **make sure the working
    directory is clean**. Be on a branch you are okay committing to.
 3. Run it like: `nixpkgs-update update "postman 7.20.0 7.21.2"`

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,7 +12,6 @@ let
   drvAttrs = attrs: with pkgs; {
     NIX = nix;
     GIT = git;
-    HUB = gitAndTools.hub;
     JQ = jq;
     TREE = tree;
     GIST = gist;

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -297,12 +297,12 @@ hubConfigField field = do
               token = T.takeWhile (/= '\n') $ head (drop 1 splits)
           return $ Just token
 
-getGithubToken :: IO Text
+getGithubToken :: IO (Maybe Text)
 getGithubToken = do
   et <- envToken
   lt <- localToken
   ht <- hubConfigField "oauth_token: "
-  return $ fromJust (et <|> lt <|> ht)
+  return (et <|> lt <|> ht)
 
 getGithubUser :: IO (GH.Name GH.Owner)
 getGithubUser = do


### PR DESCRIPTION
Also be more permissive when a GitHub token isn't available.

The one thing `hub` was used for was the initial `git clone` operation on an empty cache, for which `hub` seems overkill. Removing it means we don't need a token for any operations prior to preparing the commit, which makes it easier to test without one.