### PR TITLE
fix go drvs with `vendorHash = null`

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -8,6 +8,7 @@ module Nix
     binPath,
     build,
     cachix,
+    getAttr,
     getAttrString,
     getChangelog,
     getDerivationFile,


### PR DESCRIPTION
Fixes #338

Some `buildGoModule` derivations set `vendorHash` to `null`, which can't be retrieved using `Nix.getAttrString`, as it passes `--raw` to `nix eval`.

This PR changes `oldVendorHash` back to use `Nix.getAttr`, which does not use `--raw`.

Noticed this issue when I looked into why @r-ryantm hasn't updated `docker-buildx` in a while.
See https://github.com/NixOS/nixpkgs/pull/221023#pullrequestreview-1337929478 