### PR TITLE
Trace proc calls

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -38,13 +38,13 @@ import System.Environment.XDG.BaseDir (getUserCacheDir)
 import System.Exit()
 import System.IO.Error (tryIOError)
 import System.Posix.Env (setEnv)
-import Utils (Options (..), UpdateEnv (..), branchName, branchPrefix)
+import Utils (Options (..), UpdateEnv (..), branchName, branchPrefix, procTrace)
 
 bin :: String
 bin = fromJust ($$(envQ "GIT") :: Maybe String) <> "/bin/git"
 
 procGit :: [String] -> ProcessConfig () () ()
-procGit = proc bin
+procGit = procTrace bin
 
 clean :: ProcessConfig () () ()
 clean = silently $ procGit ["clean", "-fdx"]

--- a/src/NixpkgsReview.hs
+++ b/src/NixpkgsReview.hs
@@ -38,10 +38,10 @@ run cache commit = let timeout = "45m" :: Text in do
   -- already exists
   void $
     ourReadProcessInterleavedSem $
-      proc "rm" ["-rf", revDir cache commit]
+      Utils.procTrace "rm" ["-rf", revDir cache commit]
   (exitCode, _nixpkgsReviewOutput) <-
     ourReadProcessInterleavedSem $
-      proc "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell"]
+      Utils.procTrace "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell"]
   case exitCode of
     ExitFailure 124 -> do
       output $ "[check][nixpkgs-review] took longer than " <> timeout <> " and timed out"

--- a/src/Outpaths.hs
+++ b/src/Outpaths.hs
@@ -94,7 +94,7 @@ outPath = do
   liftIO $ T.writeFile outpathFile outPathsExpr
   liftIO $ putStrLn "[outpaths] eval start"
   currentDir <- liftIO $ System.Directory.getCurrentDirectory
-  result <- ourReadProcessInterleaved_ $ proc "nix-env" [
+  result <- ourReadProcessInterleaved_ $ Utils.procTrace "nix-env" [
     "-f", outpathFile,
     "-qaP",
     "--no-name",

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -27,7 +27,8 @@ module Utils
     regDirMode,
     outpathCacheDir,
     cacheDir,
-    worktreeDir
+    worktreeDir,
+    procTrace
   )
 where
 
@@ -64,6 +65,7 @@ import System.Posix.Temp (mkdtemp)
 import System.Posix.Types (FileMode)
 import Text.Read (readEither)
 import Type.Reflection (Typeable)
+import Debug.Trace
 
 default (T.Text)
 
@@ -88,6 +90,9 @@ data VersionMatcher
   = SingleMatcher Version
   | RangeMatcher (Boundary Version) (Boundary Version)
   deriving (Eq, Ord, Show, Read)
+
+procTrace :: String -> [String] -> ProcessConfig () () ()
+procTrace bin args = trace ("Running: " ++ show bin ++ " " ++ show args) (proc bin $ args)
 
 readField :: (Read a, Typeable a) => FieldParser a
 readField f@(Field (SQLText t) _) =


### PR DESCRIPTION
This PR includes the following changes:
- Add a wrapper function Utils.procTrace to trace the proc calls before invocation
- Use Utils.procTrace in place of proc in nixpkgs-update to trace all proc calls

For the reviewers: my experience with Haskell is extremely limited, so there are likely better ways of doing this. The intention is to trace out the proc calls, and have those traces included to the logs under https://r.ryantm.com/log/ to make it easier to debug why nixpkgs-update might fail for certain packages.

Example traces this change introduces (to stderr):

```
Running: "/nix/store/3nqhcyc7vid1npgcd0m7arg5sn325nhz-nix-2.12.0/bin/nix-env" ["-qa","libidn2-2.3.2","-f",".","--attr-path","--arg","config","{ allowBroken = true; allowUnfree = true; allowAliases = false; }","--arg","overlays","[ ]"]
Running: "/nix/store/cfx715ifm48vanlqdh7f1h3pqjpspbzd-git-2.38.1/bin/git" ["branch","-D","auto-update/libidn2"]
Running: "/nix/store/cfx715ifm48vanlqdh7f1h3pqjpspbzd-git-2.38.1/bin/git" ["worktree","add","-b","auto-update/libidn2","/home/testuser/.cache/nixpkgs-update/worktree/libidn2","HEAD"]
Running: "/nix/store/3nqhcyc7vid1npgcd0m7arg5sn325nhz-nix-2.12.0/bin/nix" ["eval",".#libidn2","--apply","p: builtins.hasAttr \"updateScript\" p"]
Running: "/nix/store/3nqhcyc7vid1npgcd0m7arg5sn325nhz-nix-2.12.0/bin/nix" ["eval","--expr","(builtins.compareVersions \"2.3.4\" \"2.3.2\")"]
Running: "env" ["EDITOR=echo","/nix/store/3nqhcyc7vid1npgcd0m7arg5sn325nhz-nix-2.12.0/bin/nix","edit","libidn2","-f","."]
Running: "/nix/store/cfx715ifm48vanlqdh7f1h3pqjpspbzd-git-2.38.1/bin/git" ["show","remotes/upstream/master:pkgs/build-support/trivial-builders.nix"]
Running: "/nix/store/cfx715ifm48vanlqdh7f1h3pqjpspbzd-git-2.38.1/bin/git" ["worktree","remove","--force","/home/testuser/.cache/nixpkgs-update/worktree/libidn2"
```
