### PR TITLE
Compatibility with Nix that does not have experimental features enabled

### DIFF
--- a/doc/interactive-updates.md
+++ b/doc/interactive-updates.md
@@ -14,10 +14,14 @@ nixpkgs-update supports interactive, single package updates via the
    no longer uses `hub` itself).
 2. Go to your local checkout of nixpkgs, and **make sure the working
    directory is clean**. Be on a branch you are okay committing to.
-3. Run it like: `nixpkgs-update update "postman 7.20.0 7.21.2"`
+3. Ensure that there is an Git origin called `upstream` which points to nixpkgs:
+   ```sh
+   git remote add upstream "https://github.com/NixOS/nixpkgs.git"
+   ```
+4. Run it like: `nixpkgs-update update "postman 7.20.0 7.21.2"`
    which mean update the package "postman" from version 7.20.0
    to version 7.21.2.
-4. It will run the updater, and, if the update builds, it will commit
+5. It will run the updater, and, if the update builds, it will commit
    the update and output a message you could use for a pull request.
 
 # Flags

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -67,7 +67,7 @@ nixEvalApply ::
   ExceptT Text m Text
 nixEvalApply applyFunc attrPath =
   ourReadProcess_
-    (proc (binPath <> "/nix") (["eval", ".#" <> T.unpack attrPath, "--apply", T.unpack applyFunc]))
+    (proc (binPath <> "/nix") (["--extra-experimental-features", "nix-command", "--extra-experimental-features", "flakes", "eval", ".#" <> T.unpack attrPath, "--apply", T.unpack applyFunc]))
     & fmapRT (fst >>> T.strip)
 
 nixEvalApplyRaw ::
@@ -77,7 +77,7 @@ nixEvalApplyRaw ::
   ExceptT Text m Text
 nixEvalApplyRaw applyFunc attrPath =
   ourReadProcess_
-    (proc (binPath <> "/nix") (["eval", ".#" <> T.unpack attrPath, "--raw", "--apply", T.unpack applyFunc]))
+    (proc (binPath <> "/nix") (["--extra-experimental-features", "nix-command", "--extra-experimental-features", "flakes", "eval", ".#" <> T.unpack attrPath, "--raw", "--apply", T.unpack applyFunc]))
     & fmapRT (fst >>> T.strip)
 
 nixEvalExpr ::
@@ -86,7 +86,7 @@ nixEvalExpr ::
   ExceptT Text m Text
 nixEvalExpr expr =
   ourReadProcess_
-    (proc (binPath <> "/nix") (["eval", "--expr", T.unpack expr]))
+    (proc (binPath <> "/nix") (["--extra-experimental-features", "nix-command", "eval", "--expr", T.unpack expr]))
     & fmapRT (fst >>> T.strip)
 
 -- Error if the "new version" is actually newer according to nix
@@ -136,7 +136,7 @@ lookupAttrPath updateEnv =
 getDerivationFile :: MonadIO m => Text -> ExceptT Text m Text
 getDerivationFile attrPath = do
   npDir <- liftIO $ Git.nixpkgsDir
-  proc "env" ["EDITOR=echo", (binPath <> "/nix"), "edit", attrPath & T.unpack, "-f", "."]
+  proc "env" ["EDITOR=echo", (binPath <> "/nix"), "--extra-experimental-features", "nix-command", "edit", attrPath & T.unpack, "-f", "."]
     & ourReadProcess_
     & fmapRT (fst >>> T.strip >>> T.stripPrefix (T.pack npDir <> "/") >>> fromJust)
 
@@ -186,7 +186,7 @@ buildCmd attrPath =
   silently $ proc (binPath <> "/nix-build") (nixBuildOptions ++ ["-A", attrPath & T.unpack])
 
 log :: Text -> ProcessConfig () () ()
-log attrPath = proc (binPath <> "/nix") ["log", "-f", ".", attrPath & T.unpack]
+log attrPath = proc (binPath <> "/nix") ["--extra-experimental-features", "nix-command", "log", "-f", ".", attrPath & T.unpack]
 
 build :: MonadIO m => Text -> ExceptT Text m ()
 build attrPath =

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -253,7 +253,8 @@ nixBuildOptions :: [String]
 nixBuildOptions =
   [ "--option",
     "sandbox",
-    "true"
+    "true",
+    "--no-out-link" -- do not pollute current directory with `result` symlink
   ]
     <> nixCommonOptions
 


### PR DESCRIPTION
Makes `nixpkgs-review` work for normal nix users.

Also fixes minor other issues that prevented me from running it successfully.

(Further I believe that @ryantm it make make sense for you to disable `experimental-features = nix-command` [which is likely in your config] while developing `nixpkgs-update`, or have test for it, because otherwise chances are high that changes only work on your machine.)