### PR TITLE
Initial work to support multiple systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "mmdoc": {
       "inputs": {
         "nixpkgs": [
@@ -53,6 +73,7 @@
     },
     "root": {
       "inputs": {
+        "flake-parts": "flake-parts",
         "mmdoc": "mmdoc",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,16 +4,36 @@
   inputs.mmdoc.url = "github:ryantm/mmdoc";
   inputs.mmdoc.inputs.nixpkgs.follows = "nixpkgs";
 
+  inputs.flake-parts.url = "github:hercules-ci/flake-parts";
+  inputs.flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+
   nixConfig.extra-substituters = "https://nixpkgs-update.cachix.org";
   nixConfig.extra-trusted-public-keys = "nixpkgs-update.cachix.org-1:6y6Z2JdoL3APdu6/+Iy8eZX2ajf09e4EE9SnxSML1W8=";
 
-  outputs = { self, nixpkgs, mmdoc } @ args:
-    {
-      packages.x86_64-linux = import ./pkgs/default.nix (args // { system = "x86_64-linux"; });
-      devShells.x86_64-linux.default = self.packages."x86_64-linux".devShell;
+  outputs = { self, nixpkgs, flake-parts, mmdoc } @ inputs:
 
-      # nix flake check is broken for these when run on x86_64-linux
-      # packages.x86_64-darwin = import ./pkgs/default.nix (args // { system = "x86_64-darwin"; });
-      # devShells.x86_64-darwin.default = self.packages."x86_64-darwin".devShell;
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem = {pkgs, system, ...}: {
+        packages = import ./pkgs/default.nix { inherit system mmdoc nixpkgs; };
+        # devShell.default = packages.${system}.devShell;
+      };
+
     };
 }
+# {
+#   # packages.x86_64-linux = import ./pkgs/default.nix (args // { system = "x86_64-linux"; });
+#   # devShells.x86_64-linux.default = self.packages."x86_64-linux".devShell;
+
+#   # nix flake check is broken for these when run on x86_64-linux
+#   # packages.x86_64-darwin = import ./pkgs/default.nix (args // { system = "x86_64-darwin"; });
+#   # devShells.x86_64-darwin.default = self.packages."x86_64-darwin".devShell;
+#   packages.aarch64-darwin = import ./pkgs/default.nix (args // { system = "aarch64-darwin"; });
+#   devShells.aarch64-darwin.default = self.packages."aarch64-darwin".devShell;
+# };

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,7 +1,6 @@
 { nixpkgs
 , mmdoc
 , system
-, self
 , ...
 }:
 
@@ -53,7 +52,7 @@ let
 
   doc = pkgs.stdenvNoCC.mkDerivation rec {
     name = "nixpkgs-update-doc";
-    src = self;
+    src = ./.;
     phases = [ "mmdocPhase" ];
     mmdocPhase = "${mmdoc.packages.${system}.mmdoc}/bin/mmdoc nixpkgs-update $src/doc $out";
   };


### PR DESCRIPTION
## Description

This PR introduces `flake-parts` to support the usage of nixpkgs-update in multiple systems.

> ⚠️ It is still in progress ⚠️  Would it be something interesting to contribute to this project? I have been using it myself in `aarch64-darwin`.