### PR TITLE
Add nix build command to Update.hs

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -568,6 +568,10 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
        ```
        nix-build -A $attrPath https://github.com/$ghUser/nixpkgs/archive/$commitRev.tar.gz
        ```
+       Or:
+       ```
+       nix build github:$ghUser/nixpkgs/$commitRev#$attrPath
+       ```
 
        After you've downloaded or built it, look at the files and if there are any, run the binaries:
        ```

--- a/test_data/expected_pr_description_1.md
+++ b/test_data/expected_pr_description_1.md
@@ -55,6 +55,10 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 ```
 nix-build -A foobar https://github.com/r-ryantm/nixpkgs/archive/af39cf77a0d42a4f6771043ec54221ed.tar.gz
 ```
+Or:
+```
+nix build github:r-ryantm/nixpkgs/af39cf77a0d42a4f6771043ec54221ed#foobar
+```
 
 After you've downloaded or built it, look at the files and if there are any, run the binaries:
 ```

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -55,6 +55,10 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 ```
 nix-build -A foobar https://github.com/r-ryantm/nixpkgs/archive/af39cf77a0d42a4f6771043ec54221ed.tar.gz
 ```
+Or:
+```
+nix build github:r-ryantm/nixpkgs/af39cf77a0d42a4f6771043ec54221ed#foobar
+```
 
 After you've downloaded or built it, look at the files and if there are any, run the binaries:
 ```


### PR DESCRIPTION
Add new command to the PR which allows to build the package with the new nix commands. E.g.:
```
nix build github:r-ryantm/nixpkgs/5026173792d483cd22517456c2b218655717e6f9#kubevpn
```

Feel free to edit the place or text as you wish. Thanks for making this tool, it helps me keep the package I maintain up to date.