### PR TITLE
Revert "Pass `--no-out-link` to `nix-build`"

### DIFF
--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -253,8 +253,7 @@ nixBuildOptions :: [String]
 nixBuildOptions =
   [ "--option",
     "sandbox",
-    "true",
-    "--no-out-link" -- do not pollute current directory with `result` symlink
+    "true"
   ]
     <> nixCommonOptions
 


### PR DESCRIPTION
Seems something in https://github.com/ryantm/nixpkgs-update/pull/353 broke the bot.

It stopped opening PRs after we updated the infra flake https://github.com/nix-community/infra/pull/726, I pinned it in https://github.com/nix-community/infra/pull/729.

I'm assuming that it was this commit as `resultLink` seems to be needed.

https://github.com/ryantm/nixpkgs-update/blob/1d413f690022a8e7d1cf14d39963da1fd67b5942/src/Nix.hs#L238-L243

https://github.com/ryantm/nixpkgs-update/blob/1d413f690022a8e7d1cf14d39963da1fd67b5942/src/Update.hs#L348