### PR TITLE
skiplist: remove `goDeps`

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -149,7 +149,6 @@ contentList =
     infixOf "buildPerlPackage" "Derivation contains buildPerlPackage",
     -- Specific skips for classes of packages
     infixOf "teams.gnome.members" "Do not update GNOME during a release cycle",
-    infixOf "goDeps" "Derivation contains goDeps attribute",
     infixOf "https://downloads.haskell.org/ghc/" "GHC packages are versioned per file"
   ]
 


### PR DESCRIPTION
I added `goDeps` back in https://github.com/ryantm/nixpkgs-update/pull/210, now there are only a few packages left that still use it.

I don't see a problem with removing this restriction, I expect that the old `goDeps` packaging is only still in use because the package upstream is inactive.

Closes https://github.com/ryantm/nixpkgs-update/issues/302