### PR TITLE
Skiplist.hs: spelling nitpick

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -184,7 +184,7 @@ skipOutpathCalcList =
 
 binariesStickAround :: Text -> (Text -> Bool, Text)
 binariesStickAround name =
-  infixOf name ("- " <> name <> "result is not automatically checekd because some binaries stick around")
+  infixOf name ("- " <> name <> " result is not automatically checked because some binaries stick around")
 
 skiplister :: Skiplist -> TextSkiplister m
 skiplister skiplist input = forM_ result throwError


### PR DESCRIPTION
minor spelling and formatting mistake in the PR text
![image](https://github.com/ryantm/nixpkgs-update/assets/30512529/0add4625-081f-4003-8a0d-b65b23a6fdab)

checekd -> checked
and add a leading space between `name` and the string
(feels like haskell could have a way to add this space via the interpolation, but the `"- "` has a trailing space...)