### PR TITLE
skiplist: add python*Packages.mmengine

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -12,9 +12,11 @@ module Skiplist
   )
 where
 
+import Data.Char (isDigit)
 import Data.Foldable (find)
 import qualified Data.Text as T
 import OurPrelude
+import Text.Regex.Applicative.Text (RE', few, psym, string, (=~))
 
 type Skiplist = [(Text -> Bool, Text)]
 
@@ -79,7 +81,10 @@ attrPathList =
     eq "imagemagick_light" "same file and version as imagemagick",
     eq "imagemagickBig" "same file and version as imagemagick",
     eq "libheimdal" "alias of heimdal",
-    eq "minio_legacy_fs" "@bachp asked to skip"
+    eq "minio_legacy_fs" "@bachp asked to skip",
+    regex
+      (string "python" *> few (psym isDigit) *> string "Packages.mmengine")
+      "takes way too long to build"
   ]
 
 nameList :: Skiplist
@@ -198,6 +203,9 @@ infixOf part reason = ((part `T.isInfixOf`), reason)
 
 eq :: Text -> Text -> (Text -> Bool, Text)
 eq part reason = ((part ==), reason)
+
+regex :: RE' a -> Text -> (Text -> Bool, Text)
+regex pat reason = (isJust . (=~ pat), reason)
 
 python :: Monad m => Int -> Text -> ExceptT Text m ()
 python numPackageRebuilds derivationContents =


### PR DESCRIPTION
As observed in https://github.com/nix-community/infra/issues/945, `python310Packages.mmengine` takes days to build. It takes at least eight days on my local machine (I finally gave up). It looks like the tests are falling back on a CPU implementation of PyTorch if there's no GPU they can use.

I think the right thing to do is for nixpkgs-update to ignore this package altogether and let maintainers update it manually.

CCing package maintainer @benxiao.