### PR TITLE
doc: update community infra link

### DIFF
--- a/doc/r-ryantm.md
+++ b/doc/r-ryantm.md
@@ -1,3 +1,3 @@
 # r-ryantm {#r-ryantm}
 
-[@r-ryantm](https://github.com/r-ryantm), is a bot account that updates Nixpkgs by making PRs that bump a package to the latest version. It runs on [community-configured infrastructure](https://github.com/nix-community/infra/tree/master/build02).
+[@r-ryantm](https://github.com/r-ryantm), is a bot account that updates Nixpkgs by making PRs that bump a package to the latest version. It runs on [community-configured infrastructure](https://nix-community.org/update-bot/).


### PR DESCRIPTION
Current link is 404, changing it to point the the community docs page for the update bot which should remain stable.

Adding links to the config and source in https://github.com/nix-community/infra/pull/1030.