### PR TITLE
don't hide `checks done` section

### DIFF
--- a/src/Update.hs
+++ b/src/Update.hs
@@ -536,10 +536,7 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
 
        ###### Impact
 
-       <details>
-       <summary>
-       <b>Checks done</b> (click to expand)
-       </summary>
+       <b>Checks done</b>
 
        ---
 
@@ -548,7 +545,6 @@ prMessage updateEnv isBroken metaDescription metaHomepage metaChangelog rewriteM
 
        ---
 
-       </details>
        <details>
        <summary>
        <b>Rebuild report</b> (if merged into master) (click to expand)

--- a/test_data/expected_pr_description_1.md
+++ b/test_data/expected_pr_description_1.md
@@ -20,10 +20,7 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ###### Impact
 
-<details>
-<summary>
-<b>Checks done</b> (click to expand)
-</summary>
+<b>Checks done</b>
 
 ---
 
@@ -32,7 +29,6 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ---
 
-</details>
 <details>
 <summary>
 <b>Rebuild report</b> (if merged into master) (click to expand)

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -20,10 +20,7 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ###### Impact
 
-<details>
-<summary>
-<b>Checks done</b> (click to expand)
-</summary>
+<b>Checks done</b>
 
 ---
 
@@ -32,7 +29,6 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 ---
 
-</details>
 <details>
 <summary>
 <b>Rebuild report</b> (if merged into master) (click to expand)


### PR DESCRIPTION
Sometimes reviewers don't expand this section so they don't see detail like this:

```
Warning: a test defined in `passthru.tests` did not pass
```

Reviews should also be waiting for ofborg to run the tests before merging (which would likely have also failed) but that isn't an issue that we can address at the moment.