### PR TITLE
skiplist: add ocaml packages

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -69,6 +69,9 @@ attrPathList =
     prefix
       "keybinder"
       "it has weird tags. see nixpkgs-update#232",
+    prefix
+      "ocaml"
+      "@vbgl asked to skip",
     infixOf
       "pysc2"
       "crashes nixpkgs-update",


### PR DESCRIPTION
vbgl, the maintainer of OCaml ecosystem, prefers that r-ryantm not make automatic PRs

See:
https://github.com/NixOS/nixpkgs/pull/283172#pullrequestreview-1847018227
https://github.com/NixOS/nixpkgs/pull/280873#pullrequestreview-1820964719
https://github.com/NixOS/nixpkgs/pull/260557#pullrequestreview-1679135594