### PR TITLE
allow nixpkgs-review to build insecure packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,7 +55,24 @@
       "inputs": {
         "mmdoc": "mmdoc",
         "nixpkgs": "nixpkgs",
+        "runtimeDeps": "runtimeDeps",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "runtimeDeps": {
+      "locked": {
+        "lastModified": 1714247354,
+        "narHash": "sha256-6dFKqP/aCKIdpOgqgIQUrRT0NOfVc14ftNcdELa4Pu4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8d7c8a78fb516c0842cc65346506a565c88014d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "treefmt-nix": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,12 @@
   inputs.treefmt-nix.url = "github:numtide/treefmt-nix";
   inputs.treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
+  inputs.runtimeDeps.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+
   nixConfig.extra-substituters = "https://nix-community.cachix.org";
   nixConfig.extra-trusted-public-keys = "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
 
-  outputs = { self, nixpkgs, mmdoc, treefmt-nix } @ args:
+  outputs = { self, nixpkgs, mmdoc, treefmt-nix, runtimeDeps } @ args:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,6 @@
 { nixpkgs
 , mmdoc
+, runtimeDeps
 , system
 , self
 , ...
@@ -7,9 +8,11 @@
 
 let
 
+  runtimePkgs = import runtimeDeps { inherit system; };
+
   pkgs = import nixpkgs { inherit system; config = { allowBroken = true; }; };
 
-  drvAttrs = attrs: with pkgs; {
+  drvAttrs = attrs: with runtimePkgs; {
     NIX = nix;
     GIT = git;
     JQ = jq;

--- a/src/NixpkgsReview.hs
+++ b/src/NixpkgsReview.hs
@@ -43,7 +43,7 @@ run cache commit =
             proc "rm" ["-rf", revDir cache commit]
         (exitCode, _nixpkgsReviewOutput) <-
           ourReadProcessInterleavedSem $
-            proc "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell"]
+            proc "timeout" [T.unpack timeout, (binPath <> "/nixpkgs-review"), "rev", T.unpack commit, "--no-shell", "--extra-nixpkgs-config", "{ allowInsecurePredicate = x: true; }"]
         case exitCode of
           ExitFailure 124 -> do
             output $ "[check][nixpkgs-review] took longer than " <> timeout <> " and timed out"


### PR DESCRIPTION
Closes https://github.com/ryantm/nixpkgs-update/issues/385

`extra-nixpkgs-config` requires `nixpkgs-review` 2.9.0, to merge this PR the flake will need to be updated as it currently has 2.8.0.

Updating the flake requires fixing some haskell breakage, not sure how trivial that is.

For now I can just override the runtime dependencies so this can be deployed.