### PR TITLE
skiplist: add monero packages

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -61,6 +61,9 @@ attrPathList =
       "deepin"
       "deepin packages are upgraded in lockstep https://github.com/NixOS/nixpkgs/pull/52327#issuecomment-447684194",
     prefix
+      "monero-"
+      "monero-cli and monero-gui packages are upgraded in lockstep",
+    prefix
       "element-desktop"
       "@Ma27 asked to skip",
     prefix


### PR DESCRIPTION
monero-gui depends on the sources of monero-cli, so they must be updated in the same pull request.
Until https://github.com/ryantm/nixpkgs-update/issues/29 is implemented, these will have to be updated manually.