### PR TITLE
Spell Nixpkgs with lower case p

### DIFF
--- a/src/Git.hs
+++ b/src/Git.hs
@@ -146,7 +146,7 @@ nixpkgsDir = do
     then getCurrentDirectory
     else getUserCacheDir "nixpkgs"
 
--- Setup a NixPkgs clone in $XDG_CACHE_DIR/nixpkgs
+-- Setup a Nixpkgs clone in $XDG_CACHE_DIR/nixpkgs
 -- Since we are going to have to fetch, git reset, clean, and commit, we setup a
 -- cache dir to avoid destroying any uncommitted work the user may have in PWD.
 setupNixpkgs :: Text -> IO ()

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -479,7 +479,7 @@ prMessage updateEnv metaDescription metaHomepage metaChangelog rewriteMsgs relea
           else "- [Compare changes on GitHub](" <> compareUrl <> ")"
       nixpkgsReviewSection =
         if nixpkgsReviewMsg == T.empty
-          then "NixPkgs review skipped"
+          then "Nixpkgs review skipped"
           else
             [interpolate|
             We have automatically built all packages that will get rebuilt due to

--- a/test/UpdateSpec.hs
+++ b/test/UpdateSpec.hs
@@ -42,7 +42,7 @@ spec = do
       T.writeFile "test_data/actual_pr_description_1.md" actual
       actual `shouldBe` expected
 
-    it "does not include NixPkgs review section when no review was done" do
+    it "does not include Nixpkgs review section when no review was done" do
       expected <- T.readFile "test_data/expected_pr_description_2.md"
       let nixpkgsReviewMsg' = ""
       let actual = Update.prMessage updateEnv metaDescription metaHomepage metaChangelog rewriteMsgs releaseUrl compareUrl resultCheckReport commitHash attrPath maintainersCc resultPath opReport cveRep cacheTestInstructions nixpkgsReviewMsg'

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -70,7 +70,7 @@ ls -la /nix/store/some-hash-path/bin
 
 ### Pre-merge build results
 
-NixPkgs review skipped
+Nixpkgs review skipped
 
 ---
 


### PR DESCRIPTION
Not the worst thing, but the one in Update.hs was very publicly visible, creating confusion around the spelling.
- Example https://github.com/NixOS/nixpkgs/pull/453685