### PR TITLE
Show logs correctly for unfree packages that fail to build

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -179,7 +179,7 @@ buildCmd attrPath =
   silently $ proc (binPath <> "/nix-build") (nixBuildOptions ++ ["-A", attrPath & T.unpack])
 
 log :: Text -> ProcessConfig () () ()
-log attrPath = proc (binPath <> "/nix") ["--extra-experimental-features", "nix-command", "log", "-f", ".", attrPath & T.unpack]
+log attrPath = proc (binPath <> "/nix") (["--extra-experimental-features", "nix-command", "log", "-f", ".", attrPath & T.unpack] <> nixCommonOptions)
 
 build :: MonadIO m => Text -> ExceptT Text m ()
 build attrPath =


### PR DESCRIPTION
Might fix #473? (I can't actually reproduce the problem locally, I guess because I permit unfree packages)

Example broken logs: https://nixpkgs-update-logs.nix-community.org/fflogs/2025-11-19.log