### PR TITLE
add `result-lib` to `resultLink`

### DIFF
--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -223,6 +223,7 @@ resultLink =
     <$> ( ourReadProcessInterleaved_ "readlink ./result"
             <|> ourReadProcessInterleaved_ "readlink ./result-bin"
             <|> ourReadProcessInterleaved_ "readlink ./result-dev"
+            <|> ourReadProcessInterleaved_ "readlink ./result-lib"
         )
     <|> throwE "Could not find result link. "
 


### PR DESCRIPTION
https://nixpkgs-update-logs.nix-community.org/libdaq/2025-11-10.log
```
No auto update branch exists
Successfully finished processing
Received ExitFailure 1 when running
Shell command: readlink ./result
Received ExitFailure 1 when running
Shell command: readlink ./result-bin
Received ExitFailure 1 when running
Shell command: readlink ./result-dev
Could not find result link. 
```