### PR TITLE
skiplist: disable discord variants

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -173,7 +173,18 @@ nameList =
     eq "ncbi-vdb" "updating this alone breaks sratoolkit",
     eq "sratoolkit" "tied to version of ncbi-vdb",
     eq "libsignal-ffi" "must match the version required by mautrix-signal",
-    eq "floorp" "big package, does not update hashes correctly (https://github.com/NixOS/nixpkgs/pull/424715#issuecomment-3163626684)"
+    eq
+      "floorp"
+      "big package, does not update hashes correctly (https://github.com/NixOS/nixpkgs/pull/424715#issuecomment-3163626684)",
+    eq
+      "discord-ptb"
+      "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956",
+    eq
+      "discord-canary"
+      "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956",
+    eq
+      "discord-development"
+      "updates through discord only https://github.com/NixOS/nixpkgs/issues/468956"
   ]
 
 contentList :: Skiplist


### PR DESCRIPTION
Disable the other variants of discord as they are all updated at once already.

See https://github.com/NixOS/nixpkgs/issues/468956
