### PR TITLE
skiplist: add ocamlPackages.extlib-1-7-7 and ocamlPackages.luv

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -117,7 +117,8 @@ attrPathList =
     eq "curlFull" "same as curl",
     eq "curlMinimal" "same as curl",
     eq "azure-sdk-for-cpp.curl" "same as curl",
-    eq "ocamlPackages.extlib-1-7-7" "versioned attribute should not be updated https://github.com/NixOS/nixpkgs/pull/294917"
+    eq "ocamlPackages.extlib-1-7-7" "versioned attribute should not be updated https://github.com/NixOS/nixpkgs/pull/294917",
+    eq "ocamlPackages.luv" "haxe depends on specific version of luv https://github.com/NixOS/nixpkgs/pull/307255"
   ]
 
 nameList :: Skiplist


### PR DESCRIPTION
Add two OCaml packages to the skiplist:

- **ocamlPackages.extlib-1-7-7**: versioned attribute should not be updated - the version is embedded in the attribute name
- **ocamlPackages.luv**: haxe depends on specific version of luv

Closes https://github.com/NixOS/nixpkgs/pull/294917
Closes https://github.com/NixOS/nixpkgs/pull/307255