### PR TITLE
Add source diff links for non-GitHub forges

### DIFF
--- a/nixpkgs-update.cabal
+++ b/nixpkgs-update.cabal
@@ -33,6 +33,7 @@ library
       Data.Hex
       DeleteMerged
       File
+      Forge
       GH
       Git
       Nix
@@ -175,6 +176,7 @@ test-suite spec
   other-modules:
       CheckSpec
       DoctestSpec
+      ForgeSpec
       UpdateSpec
       UtilsSpec
   hs-source-dirs:

--- a/src/Forge.hs
+++ b/src/Forge.hs
@@ -1,0 +1,231 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Forge
+  ( compareUrl,
+    forgeName,
+    URLParts (..),
+    Forge (..),
+    parseURLMaybe,
+  )
+where
+
+import Control.Applicative (some, (<|>))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Regex.Applicative.Text ((=~))
+import qualified Text.Regex.Applicative.Text as RE
+
+data Forge = GitHub | GitLab | Gitea | SourceHut
+  deriving (Show, Eq)
+
+data URLParts = URLParts
+  { forge :: Forge,
+    baseUrl :: Text,
+    owner :: Text,
+    repo :: Text,
+    tag :: Text
+  }
+  deriving (Show, Eq)
+
+forgeName :: Forge -> Text
+forgeName GitHub = "GitHub"
+forgeName GitLab = "GitLab"
+forgeName Gitea = "Gitea"
+forgeName SourceHut = "SourceHut"
+
+-- | Build a compare URL appropriate for the given forge.
+--
+-- >>> buildCompareUrl (URLParts GitHub "https://github.com" "owner" "repo" "v1.0") (URLParts GitHub "https://github.com" "owner" "repo" "v1.1")
+-- "https://github.com/owner/repo/compare/v1.0...v1.1"
+--
+-- >>> buildCompareUrl (URLParts GitLab "https://gitlab.com" "owner" "repo" "v1.0") (URLParts GitLab "https://gitlab.com" "owner" "repo" "v1.1")
+-- "https://gitlab.com/owner/repo/-/compare/v1.0...v1.1"
+--
+-- >>> buildCompareUrl (URLParts Gitea "https://codeberg.org" "owner" "repo" "v1.0") (URLParts Gitea "https://codeberg.org" "owner" "repo" "v1.1")
+-- "https://codeberg.org/owner/repo/compare/v1.0...v1.1"
+--
+-- >>> buildCompareUrl (URLParts SourceHut "https://git.sr.ht" "~owner" "repo" "v1.0") (URLParts SourceHut "https://git.sr.ht" "~owner" "repo" "v1.1")
+-- "https://git.sr.ht/~owner/repo/log/v1.0..v1.1"
+buildCompareUrl :: URLParts -> URLParts -> Text
+buildCompareUrl old new =
+  case forge new of
+    GitHub ->
+      baseUrl new
+        <> "/"
+        <> owner new
+        <> "/"
+        <> repo new
+        <> "/compare/"
+        <> tag old
+        <> "..."
+        <> tag new
+    GitLab ->
+      baseUrl new
+        <> "/"
+        <> owner new
+        <> "/"
+        <> repo new
+        <> "/-/compare/"
+        <> tag old
+        <> "..."
+        <> tag new
+    Gitea ->
+      baseUrl new
+        <> "/"
+        <> owner new
+        <> "/"
+        <> repo new
+        <> "/compare/"
+        <> tag old
+        <> "..."
+        <> tag new
+    SourceHut ->
+      baseUrl new
+        <> "/"
+        <> owner new
+        <> "/"
+        <> repo new
+        <> "/log/"
+        <> tag old
+        <> ".."
+        <> tag new
+
+-- | Parse a source URL into forge-specific parts.
+--
+-- GitHub release download:
+-- >>> parseURLMaybe "https://github.com/blueman-project/blueman/releases/download/2.0.7/blueman-2.0.7.tar.xz"
+-- Just (URLParts {forge = GitHub, baseUrl = "https://github.com", owner = "blueman-project", repo = "blueman", tag = "2.0.7"})
+--
+-- GitHub archive:
+-- >>> parseURLMaybe "https://github.com/arvidn/libtorrent/archive/libtorrent_1_1_11.tar.gz"
+-- Just (URLParts {forge = GitHub, baseUrl = "https://github.com", owner = "arvidn", repo = "libtorrent", tag = "libtorrent_1_1_11"})
+--
+-- GitLab archive:
+-- >>> parseURLMaybe "https://gitlab.com/inkscape/lib2geom/-/archive/1.0/lib2geom-1.0.tar.gz"
+-- Just (URLParts {forge = GitLab, baseUrl = "https://gitlab.com", owner = "inkscape", repo = "lib2geom", tag = "1.0"})
+--
+-- Self-hosted GitLab:
+-- >>> parseURLMaybe "https://gitlab.gnome.org/GNOME/glib/-/archive/2.80.0/glib-2.80.0.tar.gz"
+-- Just (URLParts {forge = GitLab, baseUrl = "https://gitlab.gnome.org", owner = "GNOME", repo = "glib", tag = "2.80.0"})
+--
+-- Codeberg archive:
+-- >>> parseURLMaybe "https://codeberg.org/dnkl/foot/archive/1.16.1.tar.gz"
+-- Just (URLParts {forge = Gitea, baseUrl = "https://codeberg.org", owner = "dnkl", repo = "foot", tag = "1.16.1"})
+--
+-- SourceHut archive:
+-- >>> parseURLMaybe "https://git.sr.ht/~sircmpwn/hare/archive/0.24.0.tar.gz"
+-- Just (URLParts {forge = SourceHut, baseUrl = "https://git.sr.ht", owner = "~sircmpwn", repo = "hare", tag = "0.24.0"})
+--
+-- Non-forge URL:
+-- >>> parseURLMaybe "https://example.com/foo-1.0.tar.gz"
+-- Nothing
+parseURLMaybe :: Text -> Maybe URLParts
+parseURLMaybe url =
+  parseGitHub url
+    <|> parseGitLab url
+    <|> parseCodeberg url
+    <|> parseSourceHut url
+
+-- | Try to generate a compare URL between two source URLs.
+--
+-- >>> compareUrl "https://github.com/owner/repo/archive/v1.0.tar.gz" "https://github.com/owner/repo/archive/v1.1.tar.gz"
+-- Just "https://github.com/owner/repo/compare/v1.0...v1.1"
+--
+-- >>> compareUrl "https://gitlab.com/owner/repo/-/archive/v1.0/repo-v1.0.tar.gz" "https://gitlab.com/owner/repo/-/archive/v1.1/repo-v1.1.tar.gz"
+-- Just "https://gitlab.com/owner/repo/-/compare/v1.0...v1.1"
+--
+-- >>> compareUrl "https://example.com/foo-1.0.tar.gz" "https://example.com/foo-1.1.tar.gz"
+-- Nothing
+compareUrl :: Text -> Text -> Maybe Text
+compareUrl urlOld urlNew = do
+  oldParts <- parseURLMaybe urlOld
+  newParts <- parseURLMaybe urlNew
+  Just (buildCompareUrl oldParts newParts)
+
+-- Internal parsers
+
+slash :: RE.RE Char Char
+slash = RE.sym '/'
+
+pathSegment :: RE.RE Char Text
+pathSegment = T.pack <$> some (RE.psym (/= '/'))
+
+extension :: RE.RE Char Text
+extension = RE.string ".zip" <|> RE.string ".tar.gz" <|> RE.string ".tar.xz" <|> RE.string ".tar.bz2"
+
+parseGitHub :: Text -> Maybe URLParts
+parseGitHub url =
+  let domain = RE.string "https://github.com/"
+      toParts o r t = URLParts GitHub "https://github.com" o r t
+      releaseDownload =
+        toParts
+          <$> (domain *> pathSegment)
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/releases/download/" *> pathSegment)
+          <* slash
+          <* pathSegment
+      archive =
+        toParts
+          <$> (domain *> pathSegment)
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/archive/" *> pathSegment)
+          <* extension
+   in url =~ (releaseDownload <|> archive)
+
+parseGitLab :: Text -> Maybe URLParts
+parseGitLab url =
+  let -- Match https://<anything-containing-gitlab>/<owner>/<repo>/-/archive/<tag>/<filename>
+      scheme = RE.string "https://"
+      -- Match domain containing "gitlab" (e.g. gitlab.com, gitlab.gnome.org, gitlab.freedesktop.org)
+      domainChar = RE.psym (\c -> c /= '/')
+      gitlabDomain = T.pack <$> some domainChar
+      toParts domain o r t = URLParts GitLab ("https://" <> domain) o r t
+      regex =
+        toParts
+          <$> (scheme *> gitlabDomain)
+          <* slash
+          <*> pathSegment
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/-/archive/" *> pathSegment)
+          <* slash
+          <* pathSegment
+   in url =~ regex
+
+parseCodeberg :: Text -> Maybe URLParts
+parseCodeberg url =
+  let domain = RE.string "https://codeberg.org/"
+      toParts o r t = URLParts Gitea "https://codeberg.org" o r t
+      releaseDownload =
+        toParts
+          <$> (domain *> pathSegment)
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/releases/download/" *> pathSegment)
+          <* slash
+          <* pathSegment
+      archive =
+        toParts
+          <$> (domain *> pathSegment)
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/archive/" *> pathSegment)
+          <* extension
+   in url =~ (releaseDownload <|> archive)
+
+parseSourceHut :: Text -> Maybe URLParts
+parseSourceHut url =
+  let domain = RE.string "https://git.sr.ht/"
+      -- SourceHut owners always start with ~
+      srhtOwner = T.pack <$> ((:) <$> RE.sym '~' <*> some (RE.psym (/= '/')))
+      toParts o r t = URLParts SourceHut "https://git.sr.ht" o r t
+      archive =
+        toParts
+          <$> (domain *> srhtOwner)
+          <* slash
+          <*> pathSegment
+          <*> (RE.string "/archive/" *> pathSegment)
+          <* extension
+   in url =~ archive

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -30,6 +30,7 @@ import qualified Data.Text.IO as T
 import Data.Time.Calendar (showGregorian)
 import Data.Time.Clock (getCurrentTime, utctDay)
 import qualified Data.Vector as V
+import qualified Forge
 import qualified GH
 import qualified Git
 import NVD (getCVEs, withVulnDB)
@@ -385,7 +386,8 @@ publishPackage log updateEnv oldSrcUrl newSrcUrl attrPath result opReport prBase
   metaChangelog <- Nix.getChangelog attrPath <|> return T.empty
   cveRep <- liftIO $ cveReport updateEnv
   releaseUrl <- GH.releaseUrl updateEnv newSrcUrl <|> return ""
-  compareUrl <- GH.compareUrl oldSrcUrl newSrcUrl <|> return ""
+  let forgeCompareUrl = maybe "" id (Forge.compareUrl oldSrcUrl newSrcUrl)
+  compareUrl <- GH.compareUrl oldSrcUrl newSrcUrl <|> return forgeCompareUrl
   maintainers <- Nix.getMaintainers attrPath
   let commitMsg = commitMessage updateEnv attrPath
   Git.commit commitMsg
@@ -482,7 +484,7 @@ prMessage updateEnv metaDescription metaHomepage metaChangelog rewriteMsgs relea
       compareUrlMessage =
         if compareUrl == T.empty
           then ""
-          else "- [Compare changes on GitHub](" <> compareUrl <> ")"
+          else "- [Compare changes upstream](" <> compareUrl <> ")"
       nixpkgsReviewSection =
         if nixpkgsReviewMsg == T.empty
           then "Nixpkgs review skipped"

--- a/test/DoctestSpec.hs
+++ b/test/DoctestSpec.hs
@@ -27,6 +27,7 @@ spec = do
           "-flate-specialise",
           "-fspecialise-aggressively",
           "-fplugin=Polysemy.Plugin",
+          "src/Forge.hs",
           "src/Version.hs",
           "src/GH.hs"
         ]

--- a/test/ForgeSpec.hs
+++ b/test/ForgeSpec.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ForgeSpec where
+
+import Forge
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "parseURLMaybe" do
+    it "parses GitHub release downloads" do
+      parseURLMaybe "https://github.com/blueman-project/blueman/releases/download/2.0.7/blueman-2.0.7.tar.xz"
+        `shouldBe` Just (URLParts GitHub "https://github.com" "blueman-project" "blueman" "2.0.7")
+
+    it "parses GitHub archives" do
+      parseURLMaybe "https://github.com/arvidn/libtorrent/archive/libtorrent_1_1_11.tar.gz"
+        `shouldBe` Just (URLParts GitHub "https://github.com" "arvidn" "libtorrent" "libtorrent_1_1_11")
+
+    it "parses GitLab archives" do
+      parseURLMaybe "https://gitlab.com/inkscape/lib2geom/-/archive/1.0/lib2geom-1.0.tar.gz"
+        `shouldBe` Just (URLParts GitLab "https://gitlab.com" "inkscape" "lib2geom" "1.0")
+
+    it "parses self-hosted GitLab archives" do
+      parseURLMaybe "https://gitlab.gnome.org/GNOME/glib/-/archive/2.80.0/glib-2.80.0.tar.gz"
+        `shouldBe` Just (URLParts GitLab "https://gitlab.gnome.org" "GNOME" "glib" "2.80.0")
+
+    it "parses Codeberg archives" do
+      parseURLMaybe "https://codeberg.org/dnkl/foot/archive/1.16.1.tar.gz"
+        `shouldBe` Just (URLParts Gitea "https://codeberg.org" "dnkl" "foot" "1.16.1")
+
+    it "parses Codeberg release downloads" do
+      parseURLMaybe "https://codeberg.org/dnkl/foot/releases/download/1.16.1/foot-1.16.1.tar.gz"
+        `shouldBe` Just (URLParts Gitea "https://codeberg.org" "dnkl" "foot" "1.16.1")
+
+    it "parses SourceHut archives" do
+      parseURLMaybe "https://git.sr.ht/~sircmpwn/hare/archive/0.24.0.tar.gz"
+        `shouldBe` Just (URLParts SourceHut "https://git.sr.ht" "~sircmpwn" "hare" "0.24.0")
+
+    it "returns Nothing for non-forge URLs" do
+      parseURLMaybe "https://example.com/foo-1.0.tar.gz"
+        `shouldBe` Nothing
+
+  describe "compareUrl" do
+    it "generates GitHub compare URLs" do
+      compareUrl
+        "https://github.com/owner/repo/archive/v1.0.tar.gz"
+        "https://github.com/owner/repo/archive/v1.1.tar.gz"
+        `shouldBe` Just "https://github.com/owner/repo/compare/v1.0...v1.1"
+
+    it "generates GitLab compare URLs" do
+      compareUrl
+        "https://gitlab.com/inkscape/lib2geom/-/archive/1.0/lib2geom-1.0.tar.gz"
+        "https://gitlab.com/inkscape/lib2geom/-/archive/1.1/lib2geom-1.1.tar.gz"
+        `shouldBe` Just "https://gitlab.com/inkscape/lib2geom/-/compare/1.0...1.1"
+
+    it "generates self-hosted GitLab compare URLs" do
+      compareUrl
+        "https://gitlab.gnome.org/GNOME/glib/-/archive/2.80.0/glib-2.80.0.tar.gz"
+        "https://gitlab.gnome.org/GNOME/glib/-/archive/2.82.0/glib-2.82.0.tar.gz"
+        `shouldBe` Just "https://gitlab.gnome.org/GNOME/glib/-/compare/2.80.0...2.82.0"
+
+    it "generates Codeberg compare URLs" do
+      compareUrl
+        "https://codeberg.org/dnkl/foot/archive/1.16.1.tar.gz"
+        "https://codeberg.org/dnkl/foot/archive/1.17.0.tar.gz"
+        `shouldBe` Just "https://codeberg.org/dnkl/foot/compare/1.16.1...1.17.0"
+
+    it "generates SourceHut compare URLs" do
+      compareUrl
+        "https://git.sr.ht/~sircmpwn/hare/archive/0.24.0.tar.gz"
+        "https://git.sr.ht/~sircmpwn/hare/archive/0.25.0.tar.gz"
+        `shouldBe` Just "https://git.sr.ht/~sircmpwn/hare/log/0.24.0..0.25.0"
+
+    it "returns Nothing for non-forge URLs" do
+      compareUrl
+        "https://example.com/foo-1.0.tar.gz"
+        "https://example.com/foo-1.1.tar.gz"
+        `shouldBe` Nothing

--- a/test_data/expected_pr_description_1.md
+++ b/test_data/expected_pr_description_1.md
@@ -15,7 +15,7 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 - [Release on GitHub](https://github.com/foobar/releases)
 
-- [Compare changes on GitHub](https://github.com/foobar/compare)
+- [Compare changes upstream](https://github.com/foobar/compare)
 
 ###### Impact
 

--- a/test_data/expected_pr_description_2.md
+++ b/test_data/expected_pr_description_2.md
@@ -15,7 +15,7 @@ meta.changelog for foobar is: "https://foobar-homepage.com/changelog/v1.2.3"
 
 - [Release on GitHub](https://github.com/foobar/releases)
 
-- [Compare changes on GitHub](https://github.com/foobar/compare)
+- [Compare changes upstream](https://github.com/foobar/compare)
 
 ###### Impact
 


### PR DESCRIPTION
Previously, compare URLs in PR descriptions only worked for GitHub-hosted sources. Add a Forge module that parses source URLs and generates compare links for GitLab (including self-hosted), Codeberg/Gitea, and SourceHut.

The GitHub compare URL path (via `GH.compareUrl` using the GitHub API) is tried first; Forge.compareUrl is used as a pure fallback for all forges. The link text is generalized from "on GitHub" to "upstream".

closes  #516.

disclaimer i used a coding agent in the creation of this patch.
