### PR TITLE
skiplist: disable unbound variants

### DIFF
--- a/src/Skiplist.hs
+++ b/src/Skiplist.hs
@@ -117,7 +117,9 @@ attrPathList =
       "same as curl",
     eq
       "yt-dlp-light"
-      "updates via yt-dlp"
+      "updates via yt-dlp",
+    eq "unbound-full" "same as unbound",
+    eq "unbound-with-systemd" "same as unbound"
   ]
 
 nameList :: Skiplist


### PR DESCRIPTION
unbound, unbound-full and unbound-with-systemd are all the same package with different build args.
