### PR TITLE
feat: verify github url before updating (fixes #552)

### DIFF
--- a/src/GH.hs
+++ b/src/GH.hs
@@ -20,6 +20,7 @@ module GH
 where
 
 import Control.Applicative (liftA2, some)
+import Control.Exception (try)
 import Data.Aeson (FromJSON)
 import Data.Bitraversable (bitraverse)
 import qualified Data.Text as T
@@ -29,7 +30,8 @@ import qualified Data.Vector as V
 import qualified Git
 import qualified GitHub as GH
 import GitHub.Data.Name (Name (..))
-import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), responseStatus)
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types.Status (statusCode)
 import OurPrelude
 import Text.Regex.Applicative.Text ((=~))
@@ -151,7 +153,18 @@ parseURLMaybe url =
    in url =~ regex
 
 urlReachable :: Text -> IO Bool
-urlReachable _ = pure True -- TODO
+urlReachable url =
+  case parseRequest $ T.unpack url of
+    Nothing -> pure False
+    Just req -> do
+      manager <- newManager tlsManagerSettings
+      res <-
+        try $
+          (httpNoBody (req {method = "HEAD"}) manager) ::
+          IO (Either HttpException (Response ()))
+      case res of
+        Left _ -> pure False
+        Right resp -> pure $ statusCode (responseStatus resp) == 200
 
 parseURL :: MonadIO m => Text -> ExceptT Text m URLParts
 parseURL url =

--- a/src/GH.hs
+++ b/src/GH.hs
@@ -11,6 +11,7 @@ module GH
     authFromToken,
     checkExistingUpdatePR,
     closedAutoUpdateRefs,
+    urlReachable,
     compareUrl,
     latestVersion,
     pr,
@@ -148,6 +149,9 @@ parseURLMaybe url =
                   <* extension
               )
    in url =~ regex
+
+urlReachable :: Text -> IO Bool
+urlReachable _ = pure True -- TODO
 
 parseURL :: MonadIO m => Text -> ExceptT Text m URLParts
 parseURL url =

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -253,6 +253,12 @@ updateAttrPath log mergeBase updateEnv@UpdateEnv {..} attrPath = do
       "The derivation has no 'version' attribute, so do not know how to figure out the version while doing an updateScript update"
       (not hasUpdateScript || isJust oldVerMay)
 
+    unless hasUpdateScript $
+      when (T.isInfixOf oldVersion oldSrcUrl) do
+        let url = oldVersion `T.replace` newVersion $ oldSrcUrl
+        reachable <- liftIO $ GH.urlReachable url
+        unless reachable $ throwE ("The new url doesn't exist: " <> url)
+
     -- One final filter
     Skiplist.content derivationContents
 


### PR DESCRIPTION
I will track progress in the PR from the start, so more experienced contributors can give feedback along the way.
I will squash and rebase at the end to have a clean history like it's done in nixpkgs.

# Error to fix
```bash
$ cabal v2-run nixpkgs-update -- update "steam-tui 0.3.0 0.3.0b https://repology.org/project/steam-tui/versions"
Up to date
[options] github_user: r-ryantm, pull_request: NO, batch_update: NO, calculate_outpaths: NO, cve_report: NO, nixpkgs-review: NO, nixpkgs_dir: "/home/user/.cache/nixpkgs", use attrpath: NO
For attrpath steam-tui, using log file: /run/user/1000/nixpkgs-update/steam-tui/2026-06-17.log
steam-tui 0.3.0 -> 0.3.0b https://repology.org/project/steam-tui/versions
attrpath: steam-tui
[version]
[version] generic version rewriter does not support multiple hashes
[rustCrateVersion]
stderr did not split as expected full stderr was:
warning: unknown experimental feature 'pipe-operators'
warning: unknown setting 'always-allow-substitutes'
this derivation will be built:
  /nix/store/07am4w42dwck9xh0hdz5sh8x1kd41rj6-source.drv
building '/nix/store/07am4w42dwck9xh0hdz5sh8x1kd41rj6-source.drv'...
structuredAttrs is enabled

trying https://github.com/dmadisetti/steam-tui/archive/0.3.0b.tar.gz
...
curl: (22) The requested URL returned error: 404
error: cannot download source from any mirror
error: Cannot build '/nix/store/07am4w42dwck9xh0hdz5sh8x1kd41rj6-source.drv'.
...
error: Build failed due to failed dependency

[result] Failed to update steam-tui 0.3.0 -> 0.3.0b https://repology.org/project/steam-tui/versions
```


# Error fixed
```
$ cabal v2-run nixpkgs-update -- update "steam-tui 0.3.0 0.3.0b https://repology.org/project/steam-tui/versions"
Up to date
[options] github_user: r-ryantm, pull_request: NO, batch_update: NO, calculate_outpaths: NO, cve_report: NO, nixpkgs-review: NO, nixpkgs_dir: "/home/user/.cache/nixpkgs", use attrpath: NO
For attrpath steam-tui, using log file: /run/user/1000/nixpkgs-update/steam-tui/2026-06-17.log
steam-tui 0.3.0 -> 0.3.0b https://repology.org/project/steam-tui/versions
attrpath: steam-tui
The new url doesn't exist: https://github.com/dmadisetti/steam-tui/archive/0.3.0b.tar.gz
[result] Failed to update steam-tui 0.3.0 -> 0.3.0b https://repology.org/project/steam-tui/versions
```

# Tests
```
$ cabal v2-test
Build profile: -w ghc-9.2.4 -O1
In order, the following will be built (use -v for more details):
 - nixpkgs-update-0.4.0 (test:spec) (first run)
Preprocessing test suite 'spec' for nixpkgs-update-0.4.0..
Building test suite 'spec' for nixpkgs-update-0.4.0..
Running 1 test suites...
Test suite spec: RUNNING...
Test suite spec: PASS
Test suite logged to:
/home/user/nixpkgs-update/check-url-reachable-#552/dist-newstyle/build/x86_64-linux/ghc-9.2.4/nixpkgs-update-0.4.0/t/spec/test/nixpkgs-update-0.4.0-spec.log
1 of 1 test suites (1 of 1 test cases) passed.
```